### PR TITLE
Fix compilation on Linux arm64

### DIFF
--- a/src/avro_extension.cpp
+++ b/src/avro_extension.cpp
@@ -632,7 +632,7 @@ AvroBindFunction(ClientContext &context, TableFunctionBindInput &input,
   return_types = result->types;
   names = result->names;
 
-  return result;
+  return std::move(result);
 }
 
 struct AvroGlobalState : GlobalTableFunctionState {
@@ -712,7 +712,7 @@ AvroGlobalInit(ClientContext &context, TableFunctionInitInput &input) {
                     bind_data.initial_reader)) {
     throw InternalException("Cannot scan files");
   }
-  return global_state_result;
+  return std::move(global_state_result);
 }
 
 static void LoadInternal(DatabaseInstance &instance) {


### PR DESCRIPTION
These moves are required to have the build pass on linux arm64

see:
```
/home/thijs/duckdb-avro/src/avro_extension.cpp:642:10: error: could not convert ‘result’ from ‘unique_ptr<duckdb::AvroBindData,default_delete<duckdb::AvroBindData>,[...]>’ to ‘unique_ptr<duckdb::FunctionData,default_delete<duckdb::FunctionData>,[...]>’
  642 |   return result;
      |          ^~~~~~
      |          |
      |          unique_ptr<duckdb::AvroBindData,default_delete<duckdb::AvroBindData>,[...]>
/home/thijs/duckdb-avro/src/avro_extension.cpp: In function ‘duckdb::unique_ptr<duckdb::GlobalTableFunctionState, std::default_delete<duckdb::GlobalTableFunctionState>, true> duckdb::AvroGlobalInit(duckdb::ClientContext&, duckdb::TableFunctionInitInput&)’:
/home/thijs/duckdb-avro/src/avro_extension.cpp:722:10: error: could not convert ‘global_state_result’ from ‘unique_ptr<duckdb::AvroGlobalState,default_delete<duckdb::AvroGlobalState>,[...]>’ to ‘unique_ptr<duckdb::GlobalTableFunctionState,default_delete<duckdb::GlobalTableFunctionState>,[...]>’
  722 |   return global_state_result;
      |          ^~~~~~~~~~~~~~~~~~~
      |          |
      |          unique_ptr<duckdb::AvroGlobalState,default_delete<duckdb::AvroGlobalState>,[...]>
```