### PR TITLE
Copy option error handling

### DIFF
--- a/test/sql/copy/invalid_option.test
+++ b/test/sql/copy/invalid_option.test
@@ -1,0 +1,21 @@
+require avro
+
+statement error
+COPY (
+	select 42
+) TO '__TEST_DIR__/test2.avro' (
+	NOT_RECOGNIZED,
+	ROOT_NAME 'test'
+);
+----
+Invalid Configuration Error: The following option(s) are not recognized: key: 'NOT_RECOGNIZED'
+
+statement error
+COPY (
+	select 42
+) TO '__TEST_DIR__/test3.avro' (
+	NOT_RECOGNIZED 'with_value',
+	ROOT_NAME 'test'
+);
+----
+Invalid Configuration Error: The following option(s) are not recognized: key: 'NOT_RECOGNIZED' with value: 'with_value'

--- a/test/sql/copy/invalid_option.test
+++ b/test/sql/copy/invalid_option.test
@@ -19,3 +19,17 @@ COPY (
 );
 ----
 Invalid Configuration Error: The following option(s) are not recognized: key: 'NOT_RECOGNIZED' with value: 'with_value'
+
+# Special case for 'METADATA', to be supported in a later release
+statement error
+COPY (
+	select 42
+) TO '__TEST_DIR__/test3.avro' (
+	METADATA {
+		'key': 'value',
+		'key2': 42
+	},
+	ROOT_NAME 'test'
+);
+----
+Not implemented Error: The 'METADATA' option is not supported in this release of Avro, please try upgrading your version ('FORCE INSTALL avro;')


### PR DESCRIPTION
Unrecognized options provided to `COPY (...) TO ... ( <options> )` now throw an error, with special handling for the `METADATA` option, to be handled in a later release