### PR TITLE
Fix compilation

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -419,18 +419,18 @@ WriteAvroGlobalState::WriteAvroGlobalState(ClientContext &context, FunctionData 
 static unique_ptr<FunctionData> WriteAvroBind(ClientContext &context, CopyFunctionBindInput &input,
                                               const vector<string> &names, const vector<LogicalType> &sql_types) {
 	auto res = make_uniq<WriteAvroBindData>(input, names, sql_types);
-	return res;
+	return std::move(res);
 }
 
 static unique_ptr<LocalFunctionData> WriteAvroInitializeLocal(ExecutionContext &context, FunctionData &bind_data_p) {
 	auto res = make_uniq<WriteAvroLocalState>(bind_data_p);
-	return res;
+	return std::move(res);
 }
 
 static unique_ptr<GlobalFunctionData> WriteAvroInitializeGlobal(ClientContext &context, FunctionData &bind_data_p,
                                                                 const string &file_path) {
 	auto res = make_uniq<WriteAvroGlobalState>(context, bind_data_p, FileSystem::GetFileSystem(context), file_path);
-	return res;
+	return std::move(res);
 }
 
 static idx_t PopulateValue(avro_value_t *target, const Value &val);

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -577,7 +577,7 @@ static void WriteAvroSink(ExecutionContext &context, FunctionData &bind_data_p, 
 	auto &buffer = global_state.memory_buffer;
 	auto expected_size = avro_writer_tell(global_state.datum_writer);
 	expected_size += WriteAvroGlobalState::SYNC_SIZE + WriteAvroGlobalState::MAX_ROW_COUNT_BYTES;
-	if (expected_size > buffer.GetCapacity()) {
+	if (static_cast<idx_t>(expected_size) > buffer.GetCapacity()) {
 		//! Resize the buffer in advance, to prevent any need for resizing below
 		buffer.Resize(NextPowerOfTwo(expected_size));
 		avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -260,13 +260,13 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
 	}
 
 	case LogicalTypeId::UNION: {
-		int discriminant;
+		int discriminant = 0;
 		avro_value union_value;
 		if (avro_value_get_discriminant(avro_val, &discriminant) ||
 		    avro_value_get_current_branch(avro_val, &union_value)) {
 			throw InvalidInputException(avro_strerror());
 		}
-		if (discriminant >= avro_type.children.size()) {
+		if (static_cast<size_t>(discriminant) >= avro_type.children.size()) {
 			throw InvalidInputException("Invalid union tag");
 		}
 
@@ -302,7 +302,7 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
 		if (avro_value_get_enum(avro_val, &enum_val)) {
 			throw InvalidInputException(avro_strerror());
 		}
-		if (enum_val < 0 || enum_val >= EnumType::GetSize(target.GetType())) {
+		if (enum_val < 0 || static_cast<idx_t>(enum_val) >= EnumType::GetSize(target.GetType())) {
 			throw InvalidInputException("Enum value out of range");
 		}
 

--- a/src/include/avro_copy.hpp
+++ b/src/include/avro_copy.hpp
@@ -28,7 +28,7 @@ public:
 		res->json_schema = json_schema;
 
 		res->interface = avro_value_iface_incref(interface);
-		return res;
+		return std::move(res);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {


### PR DESCRIPTION
When I was compilation iceberg-duckdb, I met compilation error from avro
```sh
/tmp/duckdb_iceberg/build/debug/_deps/avro_extension_fc-src/src/include/avro_copy.hpp:31:24: error: could not convert ‘res’ from ‘unique_ptr<duckdb::WriteAvroBindData,default_delete<duckdb::WriteAvroBindData>,[...]>’ to ‘unique_ptr<duckdb::FunctionData,default_delete<duckdb::FunctionData>,[...]>’
   31 |                 return res;
      |                        ^~~
      |                        |
      |                        unique_ptr<duckdb::WriteAvroBindData,default_delete<duckdb::WriteAvroBindData>,[...]>
```
Linked issue: https://github.com/duckdb/duckdb-iceberg/issues/368