### PR TITLE
List columns explicitly for deterministic results.

### DIFF
--- a/test/sql/avro.test
+++ b/test/sql/avro.test
@@ -422,7 +422,7 @@ Not implemented Error: 'union_by_name' not implemented for Avro reader yet
 
 # files with different schemas that can be safely combined are okay
 query III
-select * exclude filename FROM read_avro('test/union-name-*.avro', filename=true) order by all;
+select one, two, three FROM read_avro('test/union-name-*.avro', filename=true) order by all;
 ----
 10	2.0	s30
 11	2.1	s31


### PR DESCRIPTION
`SELECT *` is not deterministic so the column order could differ leading to failed tests, depending on the order in which files are read in. Other tests in this repository using `SELECT *` should be fine since they don't seem to rely on column order.

https://github.com/duckdb/duckdb/actions/runs/16984675625/job/48157390192?pr=18518

```
1. /home/runner/work/duckdb/duckdb/build/release/_deps/avro_extension_fc-src/test/sql/avro.test
================================================================================

Error: Wrong result in query! (/home/runner/work/duckdb/duckdb/build/release/_deps/avro_extension_fc-src/test/sql/avro.test:424)!
================================================================================
select * exclude filename FROM read_avro('test/union-name-*.avro', filename=true) order by all;
================================================================================
Mismatch on row 1, column two(index 1)
2.0 <> 10
================================================================================
Expected result:
================================================================================
10	2.0	s30
11	2.1	s31
12	2.2	s32
13	2.3	s33
14	2.4	s34
15	2.5	s35

================================================================================
Actual result:
================================================================================
2.0	10	s30
2.1	11	s31
2.2	12	s32
2.3	13	s33
2.4	14	s34
2.5	15	s35
```