### PR TITLE
Allow avro fields to not be nullable

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -565,78 +565,70 @@ static void WriteAvroSink(ExecutionContext &context, FunctionData &bind_data_p, 
 	idx_t count = input.size();
 	idx_t offset_in_datum_buffer = 0;
 
-	try {
-		for (idx_t i = 0; i < count; i++) {
+	for (idx_t i = 0; i < count; i++) {
 
-			//! Populate our avro value, estimating the size of the value as we go
-			idx_t value_size = 0;
-			for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
-				auto val = input.GetValue(col_idx, i);
+		//! Populate our avro value, estimating the size of the value as we go
+		idx_t value_size = 0;
+		for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+			auto val = input.GetValue(col_idx, i);
 
-				const char *unused_name;
-				avro_value_t column;
-				if (avro_value_get_by_index(&local_state.value, col_idx, &column, &unused_name)) {
-					throw InvalidInputException(avro_strerror());
-				}
-				value_size += PopulateValue(&column, val);
-			}
-
-			//! Prepare the datum buffer for this row
-			idx_t length = datum_buffer.GetCapacity() - offset_in_datum_buffer;
-			if (value_size > length) {
-				//! This value is too big to fit into the remaining portion of the buffer
-				idx_t new_capacity = datum_buffer.GetCapacity();
-				new_capacity += value_size;
-				datum_buffer.ResizeAndCopy(NextPowerOfTwo(new_capacity));
-			}
-			avro_writer_memory_set_dest_with_offset(global_state.datum_writer, (const char *)datum_buffer.GetData(),
-													datum_buffer.GetCapacity(), offset_in_datum_buffer);
-
-			int ret;
-			while ((ret = avro_file_writer_append_value(global_state.file_writer, &local_state.value)) == ENOSPC) {
-				auto current_capacity = datum_buffer.GetCapacity();
-				datum_buffer.ResizeAndCopy(NextPowerOfTwo(current_capacity * 2));
-				avro_writer_memory_set_dest_with_offset(global_state.datum_writer, (const char *)datum_buffer.GetData(),
-														datum_buffer.GetCapacity(), offset_in_datum_buffer);
-			}
-			if (ret) {
+			const char *unused_name;
+			avro_value_t column;
+			if (avro_value_get_by_index(&local_state.value, col_idx, &column, &unused_name)) {
 				throw InvalidInputException(avro_strerror());
 			}
-
-			offset_in_datum_buffer = avro_writer_tell(global_state.datum_writer);
-			avro_value_reset(&local_state.value);
+			value_size += PopulateValue(&column, val);
 		}
 
-		auto &buffer = global_state.memory_buffer;
-		auto expected_size = avro_writer_tell(global_state.datum_writer);
-		expected_size += WriteAvroGlobalState::SYNC_SIZE + WriteAvroGlobalState::MAX_ROW_COUNT_BYTES;
-		if (static_cast<idx_t>(expected_size) > buffer.GetCapacity()) {
-			//! Resize the buffer in advance, to prevent any need for resizing below
-			buffer.Resize(NextPowerOfTwo(expected_size));
-			avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
+		//! Prepare the datum buffer for this row
+		idx_t length = datum_buffer.GetCapacity() - offset_in_datum_buffer;
+		if (value_size > length) {
+			//! This value is too big to fit into the remaining portion of the buffer
+			idx_t new_capacity = datum_buffer.GetCapacity();
+			new_capacity += value_size;
+			datum_buffer.ResizeAndCopy(NextPowerOfTwo(new_capacity));
 		}
+		avro_writer_memory_set_dest_with_offset(global_state.datum_writer, (const char *)datum_buffer.GetData(),
+		                                        datum_buffer.GetCapacity(), offset_in_datum_buffer);
 
-		//! Flush the contents to the buffer, if it fails, resize the buffer and try again
 		int ret;
-		while ((ret = avro_file_writer_flush(global_state.file_writer)) == ENOSPC) {
-			auto current_capacity = buffer.GetCapacity();
-			buffer.Resize(NextPowerOfTwo(current_capacity * 2));
-			avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
+		while ((ret = avro_file_writer_append_value(global_state.file_writer, &local_state.value)) == ENOSPC) {
+			auto current_capacity = datum_buffer.GetCapacity();
+			datum_buffer.ResizeAndCopy(NextPowerOfTwo(current_capacity * 2));
+			avro_writer_memory_set_dest_with_offset(global_state.datum_writer, (const char *)datum_buffer.GetData(),
+			                                        datum_buffer.GetCapacity(), offset_in_datum_buffer);
 		}
 		if (ret) {
 			throw InvalidInputException(avro_strerror());
 		}
 
-		auto written_bytes = avro_writer_tell(global_state.writer);
-		global_state.WriteData(buffer.GetData(), written_bytes);
-		avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
-	} catch (const std::exception &e) {
-		// Something went wrong. Delete the file and throw the error
-		if (global_state.handle) {
-			global_state.fs.RemoveFile(global_state.handle->GetPath());
-		}
-		throw;
+		offset_in_datum_buffer = avro_writer_tell(global_state.datum_writer);
+		avro_value_reset(&local_state.value);
 	}
+
+	auto &buffer = global_state.memory_buffer;
+	auto expected_size = avro_writer_tell(global_state.datum_writer);
+	expected_size += WriteAvroGlobalState::SYNC_SIZE + WriteAvroGlobalState::MAX_ROW_COUNT_BYTES;
+	if (static_cast<idx_t>(expected_size) > buffer.GetCapacity()) {
+		//! Resize the buffer in advance, to prevent any need for resizing below
+		buffer.Resize(NextPowerOfTwo(expected_size));
+		avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
+	}
+
+	//! Flush the contents to the buffer, if it fails, resize the buffer and try again
+	int ret;
+	while ((ret = avro_file_writer_flush(global_state.file_writer)) == ENOSPC) {
+		auto current_capacity = buffer.GetCapacity();
+		buffer.Resize(NextPowerOfTwo(current_capacity * 2));
+		avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
+	}
+	if (ret) {
+		throw InvalidInputException(avro_strerror());
+	}
+
+	auto written_bytes = avro_writer_tell(global_state.writer);
+	global_state.WriteData(buffer.GetData(), written_bytes);
+	avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
 }
 
 static void WriteAvroCombine(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -632,7 +632,9 @@ static void WriteAvroSink(ExecutionContext &context, FunctionData &bind_data_p, 
 		avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
 	} catch (const std::exception &e) {
 		// Something went wrong. Delete the file and throw the error
-		global_state.fs.RemoveFile(global_state.handle->GetPath());
+		if (global_state.handle) {
+			global_state.fs.RemoveFile(global_state.handle->GetPath());
+		}
 		throw;
 	}
 }

--- a/src/avro_multi_file_info.cpp
+++ b/src/avro_multi_file_info.cpp
@@ -3,8 +3,7 @@
 
 namespace duckdb {
 
-unique_ptr<MultiFileReaderInterface>
-AvroMultiFileInfo::CreateInterface(ClientContext &context) {
+unique_ptr<MultiFileReaderInterface> AvroMultiFileInfo::CreateInterface(ClientContext &context) {
 	return make_uniq<AvroMultiFileInfo>();
 }
 

--- a/src/field_ids.cpp
+++ b/src/field_ids.cpp
@@ -110,7 +110,7 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 				const bool field_id_bool = BooleanValue::Get(field_id_bool_value);
 				field_id = FieldID(UnsafeNumericCast<int32_t>(field_id_int), field_id_bool);
 			} else {
-				field_id = FieldID(UnsafeNumericCast<int32_t>(field_id_int), true);
+				field_id = FieldID(UnsafeNumericCast<int32_t>(field_id_int));
 			}
 		}
 		auto inserted = field_ids.emplace(col_name, std::move(field_id));

--- a/src/field_ids.cpp
+++ b/src/field_ids.cpp
@@ -1,4 +1,6 @@
 #include "field_ids.hpp"
+#include "include/field_ids.hpp"
+
 #include "duckdb/common/exception/list.hpp"
 
 namespace duckdb {
@@ -8,7 +10,7 @@ namespace avro {
 FieldID::FieldID() : set(false) {
 }
 
-FieldID::FieldID(int32_t field_id_p) : set(true), field_id(field_id_p) {
+FieldID::FieldID(int32_t field_id_p, bool nullable) : set(true), field_id(field_id_p), nullable(nullable) {
 }
 
 int32_t FieldID::GetFieldId() const {
@@ -53,7 +55,7 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 	D_ASSERT(StructType::GetChildTypes(struct_type).size() == struct_children.size());
 	for (idx_t i = 0; i < struct_children.size(); i++) {
 		const auto &col_name = StringUtil::Lower(StructType::GetChildName(struct_type, i));
-		if (col_name == FieldID::DUCKDB_FIELD_ID) {
+		if (col_name == FieldID::DUCKDB_FIELD_ID || col_name == FieldID::DUCKDB_NULLABLE_ID) {
 			continue;
 		}
 
@@ -76,6 +78,7 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 		const auto &child_value = struct_children[i];
 		const auto &child_type = child_value.type();
 		optional_ptr<const Value> field_id_value;
+		optional_ptr<const Value> field_id_nullable;
 		optional_ptr<const Value> child_field_ids_value;
 
 		if (child_type.id() == LogicalTypeId::STRUCT) {
@@ -85,6 +88,8 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 				const auto &field_id_or_nested_col = StructType::GetChildName(child_type, nested_i);
 				if (field_id_or_nested_col == FieldID::DUCKDB_FIELD_ID) {
 					field_id_value = &nested_children[nested_i];
+				} else if (field_id_or_nested_col == FieldID::DUCKDB_NULLABLE_ID) {
+					field_id_nullable = &nested_children[nested_i];
 				} else {
 					child_field_ids_value = &child_value;
 				}
@@ -100,7 +105,13 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 			if (!unique_field_ids.insert(field_id_int).second) {
 				throw BinderException("Duplicate field_id %s found in FIELD_IDS", field_id_integer_value.ToString());
 			}
-			field_id = FieldID(UnsafeNumericCast<int32_t>(field_id_int));
+			if (field_id_nullable) {
+				Value field_id_bool_value = field_id_nullable->DefaultCastAs(LogicalType::BOOLEAN);
+				const bool field_id_bool = BooleanValue::Get(field_id_bool_value);
+				field_id = FieldID(UnsafeNumericCast<int32_t>(field_id_int), field_id_bool);
+			} else {
+				field_id = FieldID(UnsafeNumericCast<int32_t>(field_id_int), true);
+			}
 		}
 		auto inserted = field_ids.emplace(col_name, std::move(field_id));
 		D_ASSERT(inserted.second);

--- a/src/include/field_ids.hpp
+++ b/src/include/field_ids.hpp
@@ -14,10 +14,11 @@ namespace avro {
 struct FieldID {
 public:
 	static constexpr const auto DUCKDB_FIELD_ID = "__duckdb_field_id";
+	static constexpr const auto DUCKDB_NULLABLE_ID = "__duckdb_nullable";
 
 public:
 	FieldID();
-	explicit FieldID(int32_t field_id);
+	explicit FieldID(int32_t field_id, bool nullable);
 
 public:
 	int32_t GetFieldId() const;
@@ -25,6 +26,7 @@ public:
 public:
 	bool set = false;
 	int32_t field_id;
+	bool nullable = true;
 	case_insensitive_map_t<FieldID> children;
 };
 

--- a/src/include/field_ids.hpp
+++ b/src/include/field_ids.hpp
@@ -18,7 +18,7 @@ public:
 
 public:
 	FieldID();
-	explicit FieldID(int32_t field_id, bool nullable);
+	explicit FieldID(int32_t field_id, bool nullable = true);
 
 public:
 	int32_t GetFieldId() const;

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -38,6 +38,12 @@ COPY (
 ----
 <REGEX>:.*Cannot insert NULL to non-nullable field.*
 
+# avro file does not exist
+statement error
+select * from read_avro('__TEST_DIR__/field_ids_error.avro');
+----
+<REGEX>:.*No files found that match the pattern.*
+
 # cannot cast foo to BOOL
 statement error
 COPY (

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -7,9 +7,20 @@ require avro
 statement ok
 COPY (
 	select NULL field1
-) TO '__TEST_DIR__/field_ids.avro' (
+) TO '__TEST_DIR__/field_ids_1.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301},
+	},
+	ROOT_NAME 'test'
+);
+
+# copy null into a field (type unioned with null)
+statement ok
+COPY (
+	select NULL field1
+) TO '__TEST_DIR__/field_ids_1_nullable.avro' (
+	FIELD_IDS {
+		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': true},
 	},
 	ROOT_NAME 'test'
 );
@@ -18,7 +29,7 @@ COPY (
 statement error
 COPY (
 	select NULL field1
-) TO '__TEST_DIR__/field_ids.avro' (
+) TO '__TEST_DIR__/field_ids_error.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': false},
 	},
@@ -31,7 +42,7 @@ COPY (
 statement error
 COPY (
 	select NULL field1
-) TO '__TEST_DIR__/field_ids.avro' (
+) TO '__TEST_DIR__/field_ids_error.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': 'foo'},
 	},
@@ -46,7 +57,7 @@ COPY (
 statement ok
 COPY (
 	select 1 field1, 2 field2, 3 field3
-) TO '__TEST_DIR__/field_ids.avro' (
+) TO '__TEST_DIR__/field_ids_2.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': false},
 		'field2': 303,
@@ -56,7 +67,7 @@ COPY (
 
 # read
 query III
-select * from read_avro('__TEST_DIR__/field_ids.avro');
+select * from read_avro('__TEST_DIR__/field_ids_2.avro');
 ----
 1	2	3
 
@@ -71,7 +82,7 @@ create table t1 as select
 } data_file_nullable;
 
 statement ok
-COPY t1 TO '__TEST_DIR__/data_file.avro' (
+COPY t1 TO '__TEST_DIR__/field_ids_3.avro' (
 	FIELD_IDS {
 		'manifest_entry': {
 			'__duckdb_field_id': 0
@@ -90,7 +101,7 @@ COPY t1 TO '__TEST_DIR__/data_file.avro' (
 );
 
 query III
-select * from read_avro('__TEST_DIR__/data_file.avro');
+select * from read_avro('__TEST_DIR__/field_ids_3.avro');
 ----
 1	{'content': 1}	{'content': 2}
 
@@ -104,7 +115,7 @@ COPY (select
       {
       	'content': NULL,
       } data_file_nullable
-) TO '__TEST_DIR__/data_file.avro' (
+) TO '__TEST_DIR__/field_ids_4.avro' (
 	FIELD_IDS {
 		'manifest_entry': {
 			'__duckdb_field_id': 0

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -71,6 +71,30 @@ select * from read_avro('__TEST_DIR__/field_ids_2.avro');
 ----
 1	2	3
 
+
+# items in structs can also be nullable
+statement ok
+COPY (
+	select
+          1 manifest_entry,
+          {
+          	'content': 1,
+          } data_file_not_nullable,
+) TO '__TEST_DIR__/field_ids_3.avro' (
+	FIELD_IDS {
+		'manifest_entry': 0,
+		'data_file_not_nullable': {
+		    '__duckdb_field_id': 1,
+		    '__duckdb_nullable': false,
+		    'content': {
+		        '__duckdb_field_id': 2,
+		        '__duckdb_nullable': false
+		    }
+		}
+	},
+	ROOT_NAME 'test'
+);
+
 statement ok
 create table t1 as select
 1 manifest_entry,
@@ -82,7 +106,7 @@ create table t1 as select
 } data_file_nullable;
 
 statement ok
-COPY t1 TO '__TEST_DIR__/field_ids_3.avro' (
+COPY t1 TO '__TEST_DIR__/field_ids_4.avro' (
 	FIELD_IDS {
 		'manifest_entry': {
 			'__duckdb_field_id': 0
@@ -101,7 +125,7 @@ COPY t1 TO '__TEST_DIR__/field_ids_3.avro' (
 );
 
 query III
-select * from read_avro('__TEST_DIR__/field_ids_3.avro');
+select * from read_avro('__TEST_DIR__/field_ids_4.avro');
 ----
 1	{'content': 1}	{'content': 2}
 
@@ -115,7 +139,7 @@ COPY (select
       {
       	'content': NULL,
       } data_file_nullable
-) TO '__TEST_DIR__/field_ids_4.avro' (
+) TO '__TEST_DIR__/field_ids_5.avro' (
 	FIELD_IDS {
 		'manifest_entry': {
 			'__duckdb_field_id': 0

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -1,0 +1,226 @@
+# name: test/sql/copy/nullable.test
+# group: [copy]
+
+require avro
+
+statement ok
+COPY (
+	select NULL field1
+) TO 'field_ids.avro' (
+	FIELD_IDS {
+		'field1': {'__duckdb_field_id': 301},
+	},
+	ROOT_NAME 'test'
+);
+
+# insert null into non-nullable field
+statement error
+COPY (
+	select NULL field1
+) TO 'field_ids.avro' (
+	FIELD_IDS {
+		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': false},
+	},
+	ROOT_NAME 'test'
+);
+----
+<REGEX>:.*Cannot insert NULL to non-nullable field.*
+
+
+# test different ways to set a field id
+statement ok
+COPY (
+	select 1 field1, 2 field2, 3 field3
+) TO 'field_ids.avro' (
+	FIELD_IDS {
+		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': false},
+		'field2': 303,
+		'field3': {}
+	},
+	ROOT_NAME 'test'
+);
+
+# read
+query II
+select * from read_avro('field_ids.avro');
+----
+5	7	8
+
+statement ok
+create table t1 as select
+1 manifest_entry,
+{
+	'content': 1,
+} data_file_not_nullable,
+{
+	'content': 2,
+} data_file_nullable;
+
+statement ok
+COPY t1 TO 'data_file.avro' (
+	FIELD_IDS {
+		'manifest_entry': {
+			'__duckdb_field_id': 0
+		},
+		'data_file_not_nullable': {
+		    	'__duckdb_field_id': 2,
+		    	'__duckdb_nullable': false,
+		    	'content': 3
+		},
+        'data_file_nullable': {
+                '__duckdb_field_id': 4,
+                'content': 5
+        }
+	},
+	ROOT_NAME 'manifest_entry'
+);
+
+query III
+select * from 'data_file.avro';
+----
+1	{'content': 1}	{'content': 2}
+
+# nested nullable field throws error
+statement error
+COPY (select
+      1 manifest_entry,
+      {
+      	'content': 1,
+      } data_file_not_nullable,
+      {
+      	'content': NULL,
+      } data_file_nullable
+) TO 'data_file.avro' (
+	FIELD_IDS {
+		'manifest_entry': {
+			'__duckdb_field_id': 0
+		},
+		'data_file_not_nullable': {
+		    	'__duckdb_field_id': 2,
+		    	'__duckdb_nullable': false,
+		    	'content': {
+		    	    '__duckdb_field_id': 3,
+		    	    '__duckdb_nullable': false
+		    	}
+		},
+        'data_file_nullable': {
+                '__duckdb_field_id': 4,
+                'content': {
+                    '__duckdb_field_id': 5,
+                    '__duckdb_nullable': false
+                }
+        }
+	},
+	ROOT_NAME 'manifest_entry'
+);
+----
+<REGEX>:.*Cannot insert NULL to non-nullable field.*
+
+# other nested types
+statement ok
+create view all_types_view as select
+	MAP {
+		21: 'abc',
+		42: 'test'
+	} "field_map",
+	[
+		'a',
+		'b',
+		'c'
+	] "field_list",
+	{
+		'a': 21,
+		'b': True,
+		'c': 1.234::FLOAT
+	} "field_struct"
+;
+
+
+statement ok
+COPY (select
+      	MAP {
+      		21: 'abc',
+      		42: 'test'
+      	} "field_map",
+      	[
+      		'a',
+      		'b',
+      		'c'
+      	] "field_list",
+      	{
+      		'a': 21,
+      		'b': True,
+      		'c': 1.234::FLOAT
+      	} "field_struct"
+) TO 'nested_field_types.avro' (
+	FIELD_IDS {
+		'field_map': {
+		    'key': 0,
+		    'value': 1,
+		    '__duckdb_field_id': 2,
+		    '__duckdb_nullable': false
+		},
+		'field_list': {
+		    'element': 3,
+		    '__duckdb_field_id': 4,
+		    '__duckdb_nullable': false
+		},
+		'field_struct': {
+		    'a': 5,
+		    'b': 6,
+		    'c': 7,
+			'__duckdb_field_id': 507,
+			'__duckdb_nullable': false
+		}
+	},
+	ROOT_NAME 'manifest_file'
+);
+
+
+#
+# mode skip
+#
+# statement ok
+# COPY (
+# 	select {
+# 		'a': 21,
+# 		'b': NULL,
+# 		'c': 'test'
+# 	} field1
+# ) TO '__TEST_DIR__/field_ids.avro' (
+# 	FIELD_IDS {
+# 		'field1': {
+# 			'a': 100,
+# 			'b': 200,
+# 			'c': 300,
+# 			'__duckdb_field_id': 301
+# 		}
+# 	},
+# 	ROOT_NAME 'test'
+# );
+#
+# statement ok
+# COPY (
+# 	select [
+# 		{
+# 			'contains_null': true,
+# 			'contains_nan': true,
+# 			'lower_bound': 'blob blob',
+# 			'upper_bound': 'blob blob blob'
+# 		}
+# 	] partitions
+# ) TO '__TEST_DIR__/partitions.avro' (
+# 	FIELD_IDS {
+# 		'partitions': {
+# 			'element': {
+# 				'contains_null': 509,
+# 				'contains_nan': 518,
+# 				'lower_bound': 510,
+# 				'upper_bound': 511,
+# 				'__duckdb_field_id': 508
+# 			},
+# 			'__duckdb_field_id': 507
+# 		}
+# 	},
+# 	ROOT_NAME 'manifest_file'
+# );

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -38,6 +38,13 @@ COPY (
 ----
 <REGEX>:.*Cannot insert NULL to non-nullable field.*
 
+# No rows
+# FIXME: there should be clean up logic in the copy
+query I
+select * from read_avro('__TEST_DIR__/field_ids_error.avro');
+----
+
+
 # cannot cast foo to BOOL
 statement error
 COPY (

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -3,10 +3,11 @@
 
 require avro
 
+# copy null into a field (type unioned with null)
 statement ok
 COPY (
 	select NULL field1
-) TO 'field_ids.avro' (
+) TO '__TEST_DIR__/field_ids.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301},
 	},
@@ -17,7 +18,7 @@ COPY (
 statement error
 COPY (
 	select NULL field1
-) TO 'field_ids.avro' (
+) TO '__TEST_DIR__/field_ids.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': false},
 	},
@@ -26,25 +27,38 @@ COPY (
 ----
 <REGEX>:.*Cannot insert NULL to non-nullable field.*
 
+# cannot cast foo to BOOL
+statement error
+COPY (
+	select NULL field1
+) TO '__TEST_DIR__/field_ids.avro' (
+	FIELD_IDS {
+		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': 'foo'},
+	},
+	ROOT_NAME 'test'
+);
+----
+<REGEX>:.*Invalid Input Error: Failed to cast value:.*
 
 # test different ways to set a field id
+# via a struct
+# directly
 statement ok
 COPY (
 	select 1 field1, 2 field2, 3 field3
-) TO 'field_ids.avro' (
+) TO '__TEST_DIR__/field_ids.avro' (
 	FIELD_IDS {
 		'field1': {'__duckdb_field_id': 301, '__duckdb_nullable': false},
 		'field2': 303,
-		'field3': {}
 	},
 	ROOT_NAME 'test'
 );
 
 # read
-query II
-select * from read_avro('field_ids.avro');
+query III
+select * from read_avro('__TEST_DIR__/field_ids.avro');
 ----
-5	7	8
+1	2	3
 
 statement ok
 create table t1 as select
@@ -57,7 +71,7 @@ create table t1 as select
 } data_file_nullable;
 
 statement ok
-COPY t1 TO 'data_file.avro' (
+COPY t1 TO '__TEST_DIR__/data_file.avro' (
 	FIELD_IDS {
 		'manifest_entry': {
 			'__duckdb_field_id': 0
@@ -76,7 +90,7 @@ COPY t1 TO 'data_file.avro' (
 );
 
 query III
-select * from 'data_file.avro';
+select * from read_avro('__TEST_DIR__/data_file.avro');
 ----
 1	{'content': 1}	{'content': 2}
 
@@ -90,7 +104,7 @@ COPY (select
       {
       	'content': NULL,
       } data_file_nullable
-) TO 'data_file.avro' (
+) TO '__TEST_DIR__/data_file.avro' (
 	FIELD_IDS {
 		'manifest_entry': {
 			'__duckdb_field_id': 0
@@ -118,25 +132,6 @@ COPY (select
 
 # other nested types
 statement ok
-create view all_types_view as select
-	MAP {
-		21: 'abc',
-		42: 'test'
-	} "field_map",
-	[
-		'a',
-		'b',
-		'c'
-	] "field_list",
-	{
-		'a': 21,
-		'b': True,
-		'c': 1.234::FLOAT
-	} "field_struct"
-;
-
-
-statement ok
 COPY (select
       	MAP {
       		21: 'abc',
@@ -152,7 +147,7 @@ COPY (select
       		'b': True,
       		'c': 1.234::FLOAT
       	} "field_struct"
-) TO 'nested_field_types.avro' (
+) TO '__TEST_DIR__/nested_field_types.avro' (
 	FIELD_IDS {
 		'field_map': {
 		    'key': 0,
@@ -175,52 +170,3 @@ COPY (select
 	},
 	ROOT_NAME 'manifest_file'
 );
-
-
-#
-# mode skip
-#
-# statement ok
-# COPY (
-# 	select {
-# 		'a': 21,
-# 		'b': NULL,
-# 		'c': 'test'
-# 	} field1
-# ) TO '__TEST_DIR__/field_ids.avro' (
-# 	FIELD_IDS {
-# 		'field1': {
-# 			'a': 100,
-# 			'b': 200,
-# 			'c': 300,
-# 			'__duckdb_field_id': 301
-# 		}
-# 	},
-# 	ROOT_NAME 'test'
-# );
-#
-# statement ok
-# COPY (
-# 	select [
-# 		{
-# 			'contains_null': true,
-# 			'contains_nan': true,
-# 			'lower_bound': 'blob blob',
-# 			'upper_bound': 'blob blob blob'
-# 		}
-# 	] partitions
-# ) TO '__TEST_DIR__/partitions.avro' (
-# 	FIELD_IDS {
-# 		'partitions': {
-# 			'element': {
-# 				'contains_null': 509,
-# 				'contains_nan': 518,
-# 				'lower_bound': 510,
-# 				'upper_bound': 511,
-# 				'__duckdb_field_id': 508
-# 			},
-# 			'__duckdb_field_id': 507
-# 		}
-# 	},
-# 	ROOT_NAME 'manifest_file'
-# );

--- a/test/sql/copy/nullable.test
+++ b/test/sql/copy/nullable.test
@@ -38,12 +38,6 @@ COPY (
 ----
 <REGEX>:.*Cannot insert NULL to non-nullable field.*
 
-# avro file does not exist
-statement error
-select * from read_avro('__TEST_DIR__/field_ids_error.avro');
-----
-<REGEX>:.*No files found that match the pattern.*
-
 # cannot cast foo to BOOL
 statement error
 COPY (


### PR DESCRIPTION
Also update duckdb submodule pointer to v1.4-andium

Sometimes a field in an avro file is not allowed to be null. When this is the case we need to indicate this as such. We can do so with the FieldIds copy option. 

The test produce the following avro schemas which you can verify with the avro-tools command. I've checked them by hand and they seem valid to me.

0ne issue that still remains is that if a copy statement fails because a field was not nullable, the file still exists, but the rows are just cut off. This still needs to be fixed. I think I can just truncate the file?

field_ids_1.avro (basic test)
```
{
  "type" : "record",
  "name" : "test",
  "fields" : [ {
    "name" : "field1",
    "type" : [ "null", "int" ],
    "field-id" : 301
  } ]
}
```

field_ids_1_nullable (above test, but field1 is not nullable)
```
{
  "type" : "record",
  "name" : "test",
  "fields" : [ {
    "name" : "field1",
    "type" : "int",
    "field-id" : 301
  } ]
```

field_ids_2.avro (field1 is not nullable)
```
{
  "type" : "record",
  "name" : "test",
  "fields" : [ {
    "name" : "field1",
    "type" : "int",
    "field-id" : 301
  }, {
    "name" : "field2",
    "type" : [ "null", "int" ],
    "field-id" : 303
  }, {
    "name" : "field3",
    "type" : [ "null", "int" ]
  } ]
}
```

field_ids_3.avro (data_file_not_nullable is not unioned with null, while data_file_nullable is)
```
{
  "type" : "record",
  "name" : "manifest_entry",
  "fields" : [ {
    "name" : "manifest_entry",
    "type" : [ "null", "int" ],
    "field-id" : 0
  }, {
    "name" : "data_file_not_nullable",
    "type" : {
      "type" : "record",
      "name" : "data_file_not_nullable",
      "fields" : [ {
        "name" : "content",
        "type" : [ "null", "int" ],
        "field-id" : 3
      } ]
    },
    "field-id" : 2
  }, {
    "name" : "data_file_nullable",
    "type" : [ "null", {
      "type" : "record",
      "name" : "data_file_nullable",
      "fields" : [ {
        "name" : "content",
        "type" : [ "null", "int" ],
        "field-id" : 5
      } ]
    } ],
    "field-id" : 4
  } ]
}
```

nested_field_types.avro
```
{
  "type" : "record",
  "name" : "manifest_file",
  "fields" : [ {
    "name" : "field_map",
    "type" : {
      "type" : "array",
      "items" : {
        "type" : "record",
        "name" : "element0",
        "fields" : [ {
          "name" : "key",
          "type" : "int",
          "field-id" : 0
        }, {
          "name" : "value",
          "type" : "string",
          "field-id" : 1
        } ]
      },
      "logicalType" : "map"
    },
    "field-id" : 2
  }, {
    "name" : "field_list",
    "type" : {
      "type" : "array",
      "items" : [ "null", "string" ],
      "element-id" : 3
    },
    "field-id" : 4
  }, {
    "name" : "field_struct",
    "type" : {
      "type" : "record",
      "name" : "field_struct",
      "fields" : [ {
        "name" : "a",
        "type" : [ "null", "int" ],
        "field-id" : 5
      }, {
        "name" : "b",
        "type" : [ "null", "boolean" ],
        "field-id" : 6
      }, {
        "name" : "c",
        "type" : [ "null", "float" ],
        "field-id" : 7
      } ]
    },
    "field-id" : 507
  } ]
}
```