### PR TITLE
fix compilation on linux

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -200,8 +200,9 @@ public:
 				auto &child_type = it.second;
 				optional_ptr<avro::FieldID> child_field_id;
 				if (field_id) {
-					auto it = field_id->children.find(child_name);
-					if (it != field_id->children.end()) {
+					auto &children = field_id->children.Ids();
+					auto it = children.find(child_name);
+					if (it != children.end()) {
 						child_field_id = it->second;
 					}
 				}
@@ -216,8 +217,9 @@ public:
 			// if the type is a map, we cannot union the elements with null
 			auto is_map = type.id() == LogicalTypeId::MAP;
 			if (field_id) {
-				auto it = field_id->children.find("list");
-				if (it != field_id->children.end()) {
+				auto &children = field_id->children.Ids();
+				auto it = children.find("list");
+				if (it != children.end()) {
 					element_field_id = it->second;
 				}
 			}
@@ -266,8 +268,9 @@ public:
 			auto &name = names[i];
 			auto &type = types[i];
 			optional_ptr<avro::FieldID> field_id;
-			auto it = field_ids.find(name);
-			if (it != field_ids.end()) {
+			auto &children = field_ids.Ids();
+			auto it = children.find(name);
+			if (it != children.end()) {
 				field_id = it->second;
 			}
 			yyjson_mut_arr_add_val(array, CreateJSONType(name, type, field_id, true));
@@ -289,7 +292,7 @@ public:
 	const vector<LogicalType> &types;
 
 	string root_name = "root";
-	case_insensitive_map_t<avro::FieldID> field_ids;
+	avro::ChildFieldIDs field_ids;
 	idx_t generated_name_id = 0;
 	yyjson_mut_doc *doc = nullptr;
 	yyjson_mut_val *root_object;

--- a/src/field_ids.cpp
+++ b/src/field_ids.cpp
@@ -9,6 +9,10 @@ namespace avro {
 
 constexpr const char *FieldID::DUCKDB_FIELD_ID;
 
+case_insensitive_map_t<FieldID> &ChildFieldIDs::Ids() {
+	return *ids;
+}
+
 FieldID::FieldID() : set(false) {
 }
 
@@ -44,7 +48,7 @@ static case_insensitive_map_t<LogicalType> GetChildNameToTypeMap(const LogicalTy
 	return name_to_type_map;
 }
 
-static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<FieldID> &field_ids,
+static void GetFieldIDs(const Value &field_ids_value, ChildFieldIDs &field_ids_p,
                         unordered_set<uint32_t> &unique_field_ids,
                         const case_insensitive_map_t<LogicalType> &name_to_type_map) {
 	const auto &struct_type = field_ids_value.type();
@@ -54,6 +58,7 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 		    FieldID::DUCKDB_FIELD_ID);
 	}
 	const auto &struct_children = StructValue::GetChildren(field_ids_value);
+	auto &field_ids = field_ids_p.Ids();
 	D_ASSERT(StructType::GetChildTypes(struct_type).size() == struct_children.size());
 	for (idx_t i = 0; i < struct_children.size(); i++) {
 		const auto &col_name = StringUtil::Lower(StructType::GetChildName(struct_type, i));
@@ -132,7 +137,7 @@ static void GetFieldIDs(const Value &field_ids_value, case_insensitive_map_t<Fie
 	}
 }
 
-case_insensitive_map_t<FieldID> FieldIDUtils::ParseFieldIds(const Value &input, const vector<string> &names,
+ChildFieldIDs FieldIDUtils::ParseFieldIds(const Value &input, const vector<string> &names,
                                                             const vector<LogicalType> &types) {
 	unordered_set<uint32_t> unique_field_ids;
 	case_insensitive_map_t<LogicalType> name_to_type_map;
@@ -143,7 +148,7 @@ case_insensitive_map_t<FieldID> FieldIDUtils::ParseFieldIds(const Value &input, 
 		name_to_type_map.emplace(names[col_idx], types[col_idx]);
 	}
 
-	case_insensitive_map_t<FieldID> result;
+	ChildFieldIDs result;
 	GetFieldIDs(input, result, unique_field_ids, name_to_type_map);
 	return result;
 }

--- a/src/field_ids.cpp
+++ b/src/field_ids.cpp
@@ -10,6 +10,9 @@ namespace avro {
 constexpr const char *FieldID::DUCKDB_FIELD_ID;
 
 case_insensitive_map_t<FieldID> &ChildFieldIDs::Ids() {
+	if (!ids) {
+		ids = make_uniq<case_insensitive_map_t<FieldID>>();
+	}
 	return *ids;
 }
 

--- a/src/include/field_ids.hpp
+++ b/src/include/field_ids.hpp
@@ -11,6 +11,19 @@ namespace avro {
 
 //! NOTE: This is copied (but modified) from 'parquet_extension.cpp', ideally this lives in core DuckDB instead
 
+struct FieldID;
+
+struct ChildFieldIDs {
+public:
+	void Serialize(Serializer &serializer) const;
+	static ChildFieldIDs Deserialize(Deserializer &source);
+public:
+	ChildFieldIDs Copy() const;
+	case_insensitive_map_t<FieldID> &Ids();
+public:
+	unique_ptr<case_insensitive_map_t<FieldID>> ids;
+};
+
 struct FieldID {
 public:
 	static constexpr const auto DUCKDB_FIELD_ID = "__duckdb_field_id";
@@ -27,7 +40,7 @@ public:
 	bool set = false;
 	int32_t field_id;
 	bool nullable = true;
-	case_insensitive_map_t<FieldID> children;
+	ChildFieldIDs children;
 };
 
 struct FieldIDUtils {
@@ -35,7 +48,7 @@ public:
 	FieldIDUtils() = delete;
 
 public:
-	static case_insensitive_map_t<FieldID> ParseFieldIds(const Value &input, const vector<string> &names,
+	static ChildFieldIDs ParseFieldIds(const Value &input, const vector<string> &names,
 	                                                     const vector<LogicalType> &types);
 };
 


### PR DESCRIPTION
```
/usr/include/c++/11/bits/stl_pair.h:218:11: error: ‘std::pair<_T1, _T2>::second’ has incomplete type 218 | _T2 second; ///< The second member | ^~~~~~ In file included from /home/ec2-user/duckdb_iceberg/build/debug/_deps/avro_extension_fc-src/src/avro_copy.cpp:8: /home/ec2-user/duckdb_iceberg/build/debug/_deps/avro_extension_fc-src/src/include/field_ids.hpp:14:8: note: forward declaration of ‘struct duckdb::avro::FieldID’ 14 | struct FieldID {
```

Linux seems to not be a fan of the recursive nature of `FieldID`, so we re-introduce the middle-man that's also in the original we copied from `parquet_extension.cpp`