### PR TITLE
Add temporal, UUID, and decimal support to avro files

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -8,3 +8,4 @@ duckdb_extension_load(avro
 
 # Any extra extensions that should be built
 # e.g.: duckdb_extension_load(json)
+duckdb_extension_load(icu)

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -6,6 +6,7 @@
 #include "yyjson.hpp"
 #include "duckdb/common/printer.hpp"
 #include "field_ids.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "errno.h"
 
 using namespace duckdb_yyjson; // NOLINT
@@ -45,6 +46,25 @@ static string ConvertTypeToAvro(const LogicalType &type) {
 		return "null";
 	case LogicalTypeId::STRUCT:
 		return "record";
+	case LogicalTypeId::DATE:
+		return "int";
+	case LogicalTypeId::TIME: {
+		return "long";
+	}
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS: {
+		// captures
+		// timestamp-micros
+		return "long";
+	}
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		// timestamp tz will capture
+		// local-timestamp-micros
+		return "long";
+	}
+	case LogicalTypeId::DECIMAL: {
+		return "fixed";
+	}
 	case LogicalTypeId::ENUM:
 		//! FIXME: this should be implemented at some point
 		throw NotImplementedException("Can't convert logical type '%s' to Avro type", type.ToString());
@@ -58,6 +78,89 @@ static string ConvertTypeToAvro(const LogicalType &type) {
 	};
 
 	//! FIXME: we don't have support for 'FIXED' currently (a fixed size blob)
+}
+
+static string GetTemporalLogicalType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::DATE:
+		return "date";
+	case LogicalTypeId::TIME: {
+		// TODO: avro has a difference between time millis and time micros
+		//       millis is type:int, micros type:long
+		//       I think we will only support micros type long for now
+		return "time-micros";
+	}
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS: {
+		// captures
+		// timestamp-micros
+		return "timestamp-micros";
+	}
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		// timestamp tz will capture
+		// local-timestamp-micros
+		return "timestamp-micros";
+	}
+	case LogicalTypeId::TIMESTAMP_NS: {
+		return "timestamp-nanos";
+	}
+	default:
+		throw NotImplementedException("Can't convert logical type '%s' to Avro temporal type", type.ToString());
+	}
+}
+
+static bool RequiresLogicalType(const LogicalType &type) {
+	return type.IsTemporal() || type.id() == LogicalTypeId::DECIMAL || type.id() == LogicalTypeId::UUID;
+}
+
+uint32_t MinBytesRequiredForDecimal(int32_t precision) {
+	// Number of bits needed: ceil(precision * log2(10)) + 1 (sign bit)
+	// log2(10) ~ 10/3, but more precisely we use the fact that
+	// 10^P requires ceil(P * log2(10)) bits.
+	// Exact bit counts per precision bracket:
+	static constexpr int32_t BITS_REQUIRED[] = {
+	    0,   // precision 0 (unused)
+	    4,   // 1  -> max 9
+	    7,   // 2  -> max 99
+	    10,  // 3  -> max 999
+	    14,  // 4  -> max 9999
+	    17,  // 5
+	    20,  // 6
+	    24,  // 7
+	    27,  // 8
+	    30,  // 9
+	    34,  // 10
+	    37,  // 11
+	    40,  // 12
+	    44,  // 13
+	    47,  // 14
+	    50,  // 15
+	    54,  // 16
+	    57,  // 17
+	    60,  // 18
+	    64,  // 19
+	    67,  // 20
+	    70,  // 21
+	    74,  // 22
+	    77,  // 23
+	    80,  // 24
+	    84,  // 25
+	    87,  // 26
+	    90,  // 27
+	    94,  // 28
+	    97,  // 29
+	    100, // 30
+	    103, // 31
+	    107, // 32
+	    110, // 33
+	    113, // 34
+	    117, // 35
+	    120, // 36
+	    123, // 37
+	    127, // 38
+	};
+	auto ret = (BITS_REQUIRED[precision] + 7) / 8; // ceil(bits / 8)
+	return ret;
 }
 
 static bool IsNamedSchema(const LogicalType &type) {
@@ -141,7 +244,7 @@ public:
 	yyjson_mut_val *CreateJSONType(const string &name, const LogicalType &type, optional_ptr<avro::FieldID> field_id,
 	                               bool struct_field = false, bool union_null = true) {
 		yyjson_mut_val *object;
-		if (!type.IsNested()) {
+		if (!type.IsNested() && !RequiresLogicalType(type)) {
 			object = yyjson_mut_obj(doc);
 			yyjson_mut_obj_add_strcpy(doc, object, "type", ConvertTypeToAvro(type).c_str());
 			// {
@@ -155,7 +258,31 @@ public:
 				VerifyAvroName(name, type);
 				yyjson_mut_obj_add_strcpy(doc, object, "name", name.c_str());
 			}
-		} else {
+		}
+		if (type.IsTemporal()) {
+			object = CreateTemporalType(name, type, field_id);
+		}
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			object = yyjson_mut_obj(doc);
+			auto scale = DecimalType::GetScale(type);
+			auto width = DecimalType::GetWidth(type);
+			yyjson_mut_obj_add_strcpy(doc, object, "type", "fixed");
+			// add temporary name type because duckdb-avro-c requires it
+			yyjson_mut_obj_add_strcpy(doc, object, "name", name.c_str());
+			yyjson_mut_obj_add_strcpy(doc, object, "logicalType", "decimal");
+			yyjson_mut_obj_add_uint(doc, object, "scale", scale);
+			yyjson_mut_obj_add_uint(doc, object, "precision", width);
+			yyjson_mut_obj_add_uint(doc, object, "size", MinBytesRequiredForDecimal(width));
+		}
+		if (type.id() == LogicalTypeId::UUID) {
+			object = yyjson_mut_obj(doc);
+			yyjson_mut_obj_add_strcpy(doc, object, "type", "fixed");
+			// add temporary name type because duckdb-avro-c requires it
+			yyjson_mut_obj_add_strcpy(doc, object, "name", name.c_str());
+			yyjson_mut_obj_add_strcpy(doc, object, "logicalType", "uuid");
+			yyjson_mut_obj_add_uint(doc, object, "size", 16);
+		}
+		if (type.IsNested()) {
 			object = CreateNestedType(name, type, field_id);
 		}
 
@@ -179,6 +306,19 @@ public:
 		}
 
 		return wrapper;
+	}
+
+	yyjson_mut_val *CreateTemporalType(const string &name, const LogicalType &type,
+	                                   optional_ptr<avro::FieldID> field_id) {
+		D_ASSERT(type.IsTemporal());
+		auto object = yyjson_mut_obj(doc);
+		yyjson_mut_obj_add_strcpy(doc, object, "type", ConvertTypeToAvro(type).c_str());
+		VerifyAvroName(name, type);
+		yyjson_mut_obj_add_strcpy(doc, object, "logicalType", GetTemporalLogicalType(type).c_str());
+		if (type == LogicalTypeId::TIMESTAMP_TZ) {
+			yyjson_mut_obj_add_bool(doc, object, "adjust-to-utc", true);
+		}
+		return object;
 	}
 
 	yyjson_mut_val *CreateNestedType(const string &name, const LogicalType &type, optional_ptr<avro::FieldID> field_id,
@@ -243,8 +383,8 @@ public:
 				auto union_type = yyjson_mut_obj_add_arr(doc, object, "items");
 				yyjson_mut_arr_add_strcpy(doc, union_type, "null");
 				if (list_child.IsNested()) {
-					yyjson_mut_arr_add_val(
-					    union_type, CreateNestedType(GenerateSchemaName("list"), list_child, element_field_id));
+					yyjson_mut_arr_add_val(union_type,
+					                       CreateNestedType(GenerateSchemaName("list"), list_child, element_field_id));
 				} else {
 					yyjson_mut_arr_add_strcpy(doc, union_type, ConvertTypeToAvro(list_child).c_str());
 				}
@@ -462,8 +602,6 @@ static unique_ptr<GlobalFunctionData> WriteAvroInitializeGlobal(ClientContext &c
 	return std::move(res);
 }
 
-static idx_t PopulateValue(avro_value_t *target, const Value &val);
-
 static idx_t PopulateValue(avro_value_t *target, const Value &val) {
 	auto &type = val.type();
 
@@ -515,6 +653,117 @@ static idx_t PopulateValue(avro_value_t *target, const Value &val) {
 		auto str = val.GetValueUnsafe<string_t>();
 		avro_value_set_string_len(target, str.GetData(), str.GetSize() + 1);
 		return str.GetSize();
+	}
+	case LogicalTypeId::DATE: {
+		auto date = val.GetValueUnsafe<date_t>();
+		avro_value_set_int(target, Date::EpochDays(date));
+		return sizeof(int32_t);
+	}
+	case LogicalTypeId::TIME: {
+		auto date = val.GetValueUnsafe<dtime_t>();
+		avro_value_set_long(target, date.micros);
+		return sizeof(int64_t);
+	}
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS: {
+		auto date = val.GetValueUnsafe<timestamp_t>();
+		avro_value_set_long(target, date.value);
+		return sizeof(int64_t);
+	}
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		auto date = val.GetValueUnsafe<timestamp_tz_t>();
+
+		avro_value_set_long(target, date.value);
+		return sizeof(int64_t);
+	}
+	case LogicalTypeId::UUID: {
+		auto uuid = val.GetValueUnsafe<hugeint_t>();
+		uint8_t bytes[16];
+		BaseUUID::ToBlob(uuid, data_ptr_cast(bytes));
+		avro_value_set_fixed(target, bytes, 16);
+		return 16;
+	}
+	case LogicalTypeId::DECIMAL: {
+		// Avro expects the unscaled integer serialized as big-endian two's complement bytes. The physical value IS
+		// already the unscaled integer, you just need to convert byte order
+		uint8_t bytes[16];
+		idx_t byte_count;
+		switch (val.type().InternalType()) {
+		case PhysicalType::INT16: {
+			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
+			int16_t scaled_int16 = val.GetValueUnsafe<int16_t>();
+			vector<uint8_t> big_endian_bytes;
+			auto int16_bytes = sizeof(int16_t);
+			// push back the last X bytes to big_endian_bytes
+			// where X = bytes_needed
+			for (int i = (int16_bytes - bytes_needed); i < int16_bytes; i++) {
+				uint8_t get_8 = static_cast<uint8_t>(static_cast<int16_t>(scaled_int16 >> ((int16_bytes - i - 1) * 8)));
+				big_endian_bytes.push_back(get_8);
+			}
+			for (int i = 0; i < bytes_needed; i++) {
+				bytes[i] = big_endian_bytes[i];
+			}
+			byte_count = bytes_needed;
+			break;
+		}
+		case PhysicalType::INT32: {
+			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
+			int32_t scaled_int32 = val.GetValueUnsafe<int32_t>();
+			vector<uint8_t> big_endian_bytes;
+			auto int64_bytes = sizeof(int32_t);
+			// push back the last X bytes to big_endian_bytes
+			// where X = bytes_needed
+			for (int i = (int64_bytes - bytes_needed); i < int64_bytes; i++) {
+				uint8_t get_8 = static_cast<uint8_t>(static_cast<int32_t>(scaled_int32 >> ((int64_bytes - i - 1) * 8)));
+				big_endian_bytes.push_back(get_8);
+			}
+			for (int i = 0; i < bytes_needed; i++) {
+				bytes[i] = big_endian_bytes[i];
+			}
+			byte_count = bytes_needed;
+			break;
+		}
+		case PhysicalType::INT64: {
+			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
+			int64_t unscaled_uint64 = val.GetValueUnsafe<int64_t>();
+			vector<uint8_t> big_endian_bytes;
+			auto int64_bytes = sizeof(int64_t);
+			// push back the last X bytes to big_endian_bytes
+			// where X = bytes_needed
+			for (int i = (int64_bytes - bytes_needed); i < int64_bytes; i++) {
+				uint8_t get_8 =
+				    static_cast<uint8_t>(static_cast<int64_t>(unscaled_uint64 >> ((int64_bytes - i - 1) * 8)));
+				big_endian_bytes.push_back(get_8);
+			}
+			for (int i = 0; i < bytes_needed; i++) {
+				bytes[i] = big_endian_bytes[i];
+			}
+			byte_count = bytes_needed;
+			break;
+		}
+		case PhysicalType::INT128: {
+			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
+			hugeint_t unscaled_hugeint = val.GetValueUnsafe<hugeint_t>();
+			vector<uint8_t> big_endian_bytes;
+			auto huge_int_bytes = sizeof(hugeint_t);
+			// push back the last X bytes to big_endian_bytes
+			// where X = bytes_needed
+			for (int i = (huge_int_bytes - bytes_needed); i < huge_int_bytes; i++) {
+				uint8_t get_8 =
+				    static_cast<uint8_t>(static_cast<uhugeint_t>(unscaled_hugeint >> ((huge_int_bytes - i - 1) * 8)));
+				big_endian_bytes.push_back(get_8);
+			}
+			for (int i = 0; i < bytes_needed; i++) {
+				bytes[i] = big_endian_bytes[i];
+			}
+			byte_count = bytes_needed;
+			break;
+		}
+		default:
+			throw NotImplementedException("Unsupported decimal physical type");
+		}
+		avro_value_set_fixed(target, bytes, byte_count);
+		return byte_count;
 	}
 	case LogicalTypeId::ENUM: {
 		//! TODO: add support for ENUM

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -85,20 +85,11 @@ static string GetTemporalLogicalType(const LogicalType &type) {
 	case LogicalTypeId::DATE:
 		return "date";
 	case LogicalTypeId::TIME: {
-		// TODO: avro has a difference between time millis and time micros
-		//       millis is type:int, micros type:long
-		//       I think we will only support micros type long for now
 		return "time-micros";
 	}
 	case LogicalTypeId::TIMESTAMP:
-	case LogicalTypeId::TIMESTAMP_MS: {
-		// captures
-		// timestamp-micros
-		return "timestamp-micros";
-	}
+	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_TZ: {
-		// timestamp tz will capture
-		// local-timestamp-micros
 		return "timestamp-micros";
 	}
 	case LogicalTypeId::TIMESTAMP_NS: {
@@ -602,6 +593,18 @@ static unique_ptr<GlobalFunctionData> WriteAvroInitializeGlobal(ClientContext &c
 	return std::move(res);
 }
 
+template <typename T, typename ShiftT = T>
+static idx_t WriteDecimalAsFixedBytes(const Value &val, uint8_t *bytes, const LogicalType &type) {
+	auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
+	T value = val.GetValueUnsafe<T>();
+	auto type_bytes = static_cast<int>(sizeof(T));
+	auto start = type_bytes - static_cast<int>(bytes_needed);
+	for (int i = start; i < type_bytes; i++) {
+		bytes[i - start] = static_cast<uint8_t>(static_cast<ShiftT>(value >> ((type_bytes - i - 1) * 8)));
+	}
+	return bytes_needed;
+}
+
 static idx_t PopulateValue(avro_value_t *target, const Value &val) {
 	auto &type = val.type();
 
@@ -689,76 +692,18 @@ static idx_t PopulateValue(avro_value_t *target, const Value &val) {
 		uint8_t bytes[16];
 		idx_t byte_count;
 		switch (val.type().InternalType()) {
-		case PhysicalType::INT16: {
-			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
-			int16_t scaled_int16 = val.GetValueUnsafe<int16_t>();
-			vector<uint8_t> big_endian_bytes;
-			auto int16_bytes = sizeof(int16_t);
-			// push back the last X bytes to big_endian_bytes
-			// where X = bytes_needed
-			for (int i = (int16_bytes - bytes_needed); i < int16_bytes; i++) {
-				uint8_t get_8 = static_cast<uint8_t>(static_cast<int16_t>(scaled_int16 >> ((int16_bytes - i - 1) * 8)));
-				big_endian_bytes.push_back(get_8);
-			}
-			for (int i = 0; i < bytes_needed; i++) {
-				bytes[i] = big_endian_bytes[i];
-			}
-			byte_count = bytes_needed;
+		case PhysicalType::INT16:
+			byte_count = WriteDecimalAsFixedBytes<int16_t>(val, bytes, type);
 			break;
-		}
-		case PhysicalType::INT32: {
-			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
-			int32_t scaled_int32 = val.GetValueUnsafe<int32_t>();
-			vector<uint8_t> big_endian_bytes;
-			auto int64_bytes = sizeof(int32_t);
-			// push back the last X bytes to big_endian_bytes
-			// where X = bytes_needed
-			for (int i = (int64_bytes - bytes_needed); i < int64_bytes; i++) {
-				uint8_t get_8 = static_cast<uint8_t>(static_cast<int32_t>(scaled_int32 >> ((int64_bytes - i - 1) * 8)));
-				big_endian_bytes.push_back(get_8);
-			}
-			for (int i = 0; i < bytes_needed; i++) {
-				bytes[i] = big_endian_bytes[i];
-			}
-			byte_count = bytes_needed;
+		case PhysicalType::INT32:
+			byte_count = WriteDecimalAsFixedBytes<int32_t>(val, bytes, type);
 			break;
-		}
-		case PhysicalType::INT64: {
-			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
-			int64_t unscaled_uint64 = val.GetValueUnsafe<int64_t>();
-			vector<uint8_t> big_endian_bytes;
-			auto int64_bytes = sizeof(int64_t);
-			// push back the last X bytes to big_endian_bytes
-			// where X = bytes_needed
-			for (int i = (int64_bytes - bytes_needed); i < int64_bytes; i++) {
-				uint8_t get_8 =
-				    static_cast<uint8_t>(static_cast<int64_t>(unscaled_uint64 >> ((int64_bytes - i - 1) * 8)));
-				big_endian_bytes.push_back(get_8);
-			}
-			for (int i = 0; i < bytes_needed; i++) {
-				bytes[i] = big_endian_bytes[i];
-			}
-			byte_count = bytes_needed;
+		case PhysicalType::INT64:
+			byte_count = WriteDecimalAsFixedBytes<int64_t>(val, bytes, type);
 			break;
-		}
-		case PhysicalType::INT128: {
-			auto bytes_needed = MinBytesRequiredForDecimal(DecimalType::GetWidth(type));
-			hugeint_t unscaled_hugeint = val.GetValueUnsafe<hugeint_t>();
-			vector<uint8_t> big_endian_bytes;
-			auto huge_int_bytes = sizeof(hugeint_t);
-			// push back the last X bytes to big_endian_bytes
-			// where X = bytes_needed
-			for (int i = (huge_int_bytes - bytes_needed); i < huge_int_bytes; i++) {
-				uint8_t get_8 =
-				    static_cast<uint8_t>(static_cast<uhugeint_t>(unscaled_hugeint >> ((huge_int_bytes - i - 1) * 8)));
-				big_endian_bytes.push_back(get_8);
-			}
-			for (int i = 0; i < bytes_needed; i++) {
-				bytes[i] = big_endian_bytes[i];
-			}
-			byte_count = bytes_needed;
+		case PhysicalType::INT128:
+			byte_count = WriteDecimalAsFixedBytes<hugeint_t, uhugeint_t>(val, bytes, type);
 			break;
-		}
 		default:
 			throw NotImplementedException("Unsupported decimal physical type");
 		}

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -52,6 +52,7 @@ static string ConvertTypeToAvro(const LogicalType &type) {
 		return "long";
 	}
 	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_MS: {
 		// captures
 		// timestamp-micros
@@ -668,6 +669,7 @@ static idx_t PopulateValue(avro_value_t *target, const Value &val) {
 		return sizeof(int64_t);
 	}
 	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::TIMESTAMP_MS: {
 		auto date = val.GetValueUnsafe<timestamp_t>();
 		avro_value_set_long(target, date.value);

--- a/src/avro_multi_file_info.cpp
+++ b/src/avro_multi_file_info.cpp
@@ -122,7 +122,7 @@ bool AvroReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionSt
 }
 
 AsyncResult AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
-                      LocalTableFunctionState &local_state_p, DataChunk &chunk) {
+                             LocalTableFunctionState &local_state_p, DataChunk &chunk) {
 	Read(chunk);
 	return chunk.size() ? AsyncResult(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResult(SourceResultType::FINISHED);
 }

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -3,27 +3,72 @@
 #include "duckdb/storage/caching_file_system.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
+static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema) {
+	auto logical_type_raw = avro_schema_logical_type(avro_schema);
+	if (!logical_type_raw) {
+		return LogicalType::INVALID;
+	}
+	string logical_type = logical_type_raw;
+	if (logical_type == "date") {
+		return LogicalType::DATE;
+	}
+	if (logical_type == "decimal") {
+		auto scale = avro_schema_scale(avro_schema);
+		auto precision = avro_schema_precision(avro_schema);
+		return LogicalType::DECIMAL(precision, scale);
+	}
+	if (logical_type == "time-micros") {
+		return LogicalType::TIME;
+	}
+	if (logical_type == "timestamp-micros") {
+		auto adjust_to_utc = avro_schema_adjust_to_utc(avro_schema);
+		// -1 doesn't exist
+		if (adjust_to_utc > 0) {
+			return LogicalType::TIMESTAMP_TZ;
+		}
+		return LogicalType::TIMESTAMP;
+	}
+	if (logical_type == "timestamp-nanos") {
+		auto adjust_to_utc = avro_schema_adjust_to_utc(avro_schema);
+		if (adjust_to_utc) {
+			throw NotImplementedException("Avro timestamp-nanos with adjust_to_utc not supported");
+		}
+		return LogicalType::TIMESTAMP_NS;
+	}
+	if (logical_type == "uuid") {
+		auto size = avro_schema_fixed_size(avro_schema);
+		if (size != 16) {
+			throw InvalidConfigurationException("logical type is uuid, but size != 16");
+		}
+		return LogicalType::UUID;
+	}
+	throw NotImplementedException("Unknown Avro logical type %s", logical_type);
+}
+
 static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string> parent_schema_names) {
+	auto duckdb_logical_type = AvroLogicalTypeToLogicalType(avro_schema);
+	bool has_logical_type = duckdb_logical_type != LogicalType::INVALID;
 	switch (avro_typeof(avro_schema)) {
 	case AVRO_NULL:
 		return AvroType(AVRO_NULL, LogicalType::SQLNULL);
 	case AVRO_BOOLEAN:
 		return AvroType(AVRO_BOOLEAN, LogicalType::BOOLEAN);
 	case AVRO_INT32:
-		return AvroType(AVRO_INT32, LogicalType::INTEGER);
+		return AvroType(AVRO_INT32, has_logical_type ? duckdb_logical_type : LogicalType::INTEGER);
 	case AVRO_INT64:
-		return AvroType(AVRO_INT64, LogicalType::BIGINT);
+		return AvroType(AVRO_INT64, has_logical_type ? duckdb_logical_type : LogicalType::BIGINT);
 	case AVRO_FLOAT:
-		return AvroType(AVRO_FLOAT, LogicalType::FLOAT);
+		return AvroType(AVRO_FLOAT, has_logical_type ? duckdb_logical_type : LogicalType::FLOAT);
 	case AVRO_DOUBLE:
-		return AvroType(AVRO_DOUBLE, LogicalType::DOUBLE);
+		return AvroType(AVRO_DOUBLE, has_logical_type ? duckdb_logical_type : LogicalType::DOUBLE);
 	case AVRO_BYTES:
-		return AvroType(AVRO_BYTES, LogicalType::BLOB);
+		return AvroType(AVRO_BYTES, has_logical_type ? duckdb_logical_type : LogicalType::BLOB);
 	case AVRO_STRING:
-		return AvroType(AVRO_STRING, LogicalType::VARCHAR);
+		return AvroType(AVRO_STRING, has_logical_type ? duckdb_logical_type : LogicalType::VARCHAR);
 	case AVRO_UNION: {
 		auto num_children = avro_schema_union_size(avro_schema);
 		child_list_t<AvroType> union_children;
@@ -79,7 +124,7 @@ static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string
 		return AvroType(AVRO_ENUM, LogicalType::ENUM(levels, size));
 	}
 	case AVRO_FIXED: {
-		return AvroType(AVRO_FIXED, LogicalType::BLOB);
+		return AvroType(AVRO_FIXED, has_logical_type ? duckdb_logical_type : LogicalType::BLOB);
 	}
 	case AVRO_ARRAY: {
 		auto child_schema = avro_schema_array_items(avro_schema);
@@ -174,12 +219,17 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
 		FlatVector::GetData<uint8_t>(target)[out_idx] = bool_val != 0;
 		break;
 	}
+	case LogicalTypeId::DATE:
 	case LogicalTypeId::INTEGER: {
 		if (avro_value_get_int(avro_val, &FlatVector::GetData<int32_t>(target)[out_idx])) {
 			throw InvalidInputException(avro_strerror());
 		}
 		break;
 	}
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::BIGINT: {
 		if (avro_value_get_long(avro_val, &FlatVector::GetData<int64_t>(target)[out_idx])) {
 			throw InvalidInputException(avro_strerror());
@@ -195,6 +245,120 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
 	case LogicalTypeId::DOUBLE: {
 		if (avro_value_get_double(avro_val, &FlatVector::GetData<double>(target)[out_idx])) {
 			throw InvalidInputException(avro_strerror());
+		}
+		break;
+	}
+	case LogicalTypeId::UUID: {
+		size_t fixed_size = 16;
+		const void *fixed_data;
+		if (avro_value_get_fixed(avro_val, &fixed_data, &fixed_size)) {
+			throw InvalidInputException(avro_strerror());
+		}
+		FlatVector::GetData<hugeint_t>(target)[out_idx] = BaseUUID::FromBlob(const_data_ptr_cast(fixed_data));
+		break;
+	}
+	case LogicalTypeId::DECIMAL: {
+		// decimals should never be more than 16
+		const uint8_t bytes_data[16] = {};
+		const void *ptr = bytes_data;
+		size_t bytes_size;
+		avro_wrapped_buffer bytes_buf = AVRO_WRAPPED_BUFFER_EMPTY;
+
+		if (avro_type.avro_type == AVRO_BYTES) {
+			if (avro_value_grab_bytes(avro_val, &bytes_buf)) {
+				throw InvalidInputException(avro_strerror());
+			}
+			ptr = bytes_buf.buf;
+			bytes_size = bytes_buf.size;
+		} else { // AVRO_FIXED
+			if (avro_value_get_fixed(avro_val, &ptr, &bytes_size)) {
+				throw InvalidInputException(avro_strerror());
+			}
+		}
+
+		auto raw = const_data_ptr_cast(ptr);
+		// Sign bit is in the MSB of the first byte
+		bool negative = bytes_size > 0 && (raw[0] & 0x80);
+
+		switch (avro_type.duckdb_type.InternalType()) {
+		case PhysicalType::INT16: {
+			uint16_t result = negative ? 0xFFFF : 0;
+			for (idx_t i = 0; i < bytes_size; i++) {
+				result = (result << 8) | raw[i];
+			}
+			FlatVector::GetData<int16_t>(target)[out_idx] = (int16_t)result;
+			break;
+		}
+		case PhysicalType::INT32: {
+			uint32_t result = negative ? 0xFFFFFFFF : 0;
+			for (idx_t i = 0; i < bytes_size; i++) {
+				result = (result << 8) | raw[i];
+			}
+			FlatVector::GetData<int32_t>(target)[out_idx] = (int32_t)result;
+			break;
+		}
+		case PhysicalType::INT64: {
+			uint64_t result = negative ? ~0ULL : 0;
+			for (idx_t i = 0; i < bytes_size; i++) {
+				result = (result << 8) | raw[i];
+			}
+			FlatVector::GetData<int64_t>(target)[out_idx] = (int64_t)result;
+			break;
+		}
+		case PhysicalType::INT128: {
+			int64_t upper_val = 0;
+			uint64_t lower_val = 0;
+
+			// Calculate how many bytes go into upper and lower parts
+			idx_t upper_bytes;
+			if (bytes_size == 8) {
+				int64_t lower_val_signed = 0;
+				for (idx_t i = 0; i < bytes_size; i++) {
+					int64_t raw_byte = raw[i];
+					lower_val_signed |= (raw_byte << ((7 - i) * 8));
+				}
+				upper_bytes = 0;
+				auto ret = hugeint_t(lower_val_signed);
+				FlatVector::GetData<hugeint_t>(target)[out_idx] = ret;
+				break;
+			} else {
+				upper_bytes = (bytes_size <= sizeof(uint64_t)) ? bytes_size : (bytes_size - sizeof(uint64_t));
+			}
+
+			// Read upper part (big-endian)
+			// TODO: upper part might be sign extended bti.
+			for (idx_t i = 0; i < upper_bytes; i++) {
+				upper_val = (upper_val << 8) | raw[i];
+			}
+
+			// Handle sign extension for negative numbers
+			if (bytes_size > 0 && (raw[0] & 0x80)) {
+				// Fill remaining bytes with 1s for negative numbers
+				if (upper_bytes < sizeof(int64_t)) {
+					// Create a mask with 1s in the upper bits that need to be filled
+					int64_t mask = ((int64_t)1 << ((sizeof(int64_t) - upper_bytes) * 8)) - 1;
+					mask = mask << (upper_bytes * 8);
+					upper_val |= mask;
+				}
+			}
+
+			// Read lower part if there are remaining bytes
+			if (bytes_size > sizeof(int64_t)) {
+				for (idx_t i = upper_bytes; i < bytes_size; i++) {
+					lower_val = (lower_val << 8) | raw[i];
+				}
+			}
+
+			auto ret = hugeint_t(upper_val, lower_val);
+			FlatVector::GetData<hugeint_t>(target)[out_idx] = ret;
+			break;
+		}
+		default:
+			throw NotImplementedException("Unsupported decimal physical type");
+		}
+
+		if (avro_type.avro_type == AVRO_BYTES) {
+			bytes_buf.free(&bytes_buf);
 		}
 		break;
 	}

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -44,7 +44,7 @@ static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema) {
 	}
 	if (logical_type == "timestamp-nanos") {
 		auto adjust_to_utc = avro_schema_adjust_to_utc(avro_schema);
-		if (adjust_to_utc) {
+		if (adjust_to_utc > 0) {
 			throw NotImplementedException("Avro timestamp-nanos with adjust_to_utc not supported");
 		}
 		return LogicalType::TIMESTAMP_NS;

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema) {
 	auto logical_type_raw = avro_schema_logical_type(avro_schema);
-	if (!logical_type_raw) {
+	if (!logical_type_raw || avro_schema_array_is_map(avro_schema)) {
 		return LogicalType::INVALID;
 	}
 	string logical_type = logical_type_raw;

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -46,6 +46,11 @@ static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema) {
 		}
 		return LogicalType::UUID;
 	}
+	if (logical_type == "time-millis" || logical_type == "timestamp-millis" ||
+	    logical_type == "local-timestamp-millis") {
+		throw NotImplementedException(
+		    "Avro logical type %s not supported. Please convert temporal types to micro first", logical_type);
+	}
 	throw NotImplementedException("Unknown Avro logical type %s", logical_type);
 }
 

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -9,8 +9,18 @@ namespace duckdb {
 
 static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema) {
 	auto logical_type_raw = avro_schema_logical_type(avro_schema);
-	if (!logical_type_raw || avro_schema_array_is_map(avro_schema)) {
+	if (!logical_type_raw) {
 		return LogicalType::INVALID;
+	}
+	// any nested types are handled switch case in TransformSchema
+	switch (avro_typeof(avro_schema)) {
+	case AVRO_ARRAY:
+	case AVRO_ENUM:
+	case AVRO_MAP:
+	case AVRO_RECORD:
+		return LogicalType::INVALID;
+	default:
+		break;
 	}
 	string logical_type = logical_type_raw;
 	if (logical_type == "date") {

--- a/src/field_ids.cpp
+++ b/src/field_ids.cpp
@@ -141,7 +141,7 @@ static void GetFieldIDs(const Value &field_ids_value, ChildFieldIDs &field_ids_p
 }
 
 ChildFieldIDs FieldIDUtils::ParseFieldIds(const Value &input, const vector<string> &names,
-                                                            const vector<LogicalType> &types) {
+                                          const vector<LogicalType> &types) {
 	unordered_set<uint32_t> unique_field_ids;
 	case_insensitive_map_t<LogicalType> name_to_type_map;
 	for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {

--- a/src/include/avro_reader.hpp
+++ b/src/include/avro_reader.hpp
@@ -24,8 +24,8 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
-	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state, LocalTableFunctionState &local_state,
-	          DataChunk &chunk) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
 
 public:
 	avro_file_reader_t reader;

--- a/src/include/field_ids.hpp
+++ b/src/include/field_ids.hpp
@@ -17,9 +17,11 @@ struct ChildFieldIDs {
 public:
 	void Serialize(Serializer &serializer) const;
 	static ChildFieldIDs Deserialize(Deserializer &source);
+
 public:
 	ChildFieldIDs Copy() const;
 	case_insensitive_map_t<FieldID> &Ids();
+
 public:
 	unique_ptr<case_insensitive_map_t<FieldID>> ids;
 };
@@ -49,7 +51,7 @@ public:
 
 public:
 	static ChildFieldIDs ParseFieldIds(const Value &input, const vector<string> &names,
-	                                                     const vector<LogicalType> &types);
+	                                   const vector<LogicalType> &types);
 };
 
 } // namespace avro

--- a/test/sql/copy/test_decimal_types.test
+++ b/test/sql/copy/test_decimal_types.test
@@ -1,0 +1,155 @@
+# name: test/sql/copy/test_decimal_types.test
+# group: [copy]
+
+require avro
+
+require icu
+
+statement ok
+COPY (
+    from values (12.23232::DECIMAL(18,5)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT typeof(decimal_col) FROM read_avro('__TEST_DIR__/decimal_type.avro') LIMIT 1;
+----
+DECIMAL(18,5)
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+12.23232
+NULL
+
+statement ok
+COPY (
+    from values (-12.23232::DECIMAL(18,5)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT typeof(decimal_col) FROM read_avro('__TEST_DIR__/decimal_type.avro') LIMIT 1;
+----
+DECIMAL(18,5)
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+-12.23232
+NULL
+
+
+statement ok
+COPY (
+    from values (1000000000.3::DECIMAL(20,1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT typeof(decimal_col) FROM read_avro('__TEST_DIR__/decimal_type.avro') LIMIT 1;
+----
+DECIMAL(20,1)
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+1000000000.3
+NULL
+
+
+# check sign extensions on decimal scales > 18
+statement ok
+COPY (
+    from values (-1000000000.3::DECIMAL(20,1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT typeof(decimal_col) FROM read_avro('__TEST_DIR__/decimal_type.avro') LIMIT 1;
+----
+DECIMAL(20,1)
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+-1000000000.3
+NULL
+
+
+
+statement ok
+COPY (
+    from values (1000000000.3::DECIMAL(19,1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT typeof(decimal_col) FROM read_avro('__TEST_DIR__/decimal_type.avro') LIMIT 1;
+----
+DECIMAL(19,1)
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+1000000000.3
+NULL
+
+
+# check sign extensions on decimal scales > 18
+statement ok
+COPY (
+    from values (-1000000000.3::DECIMAL(19,1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT typeof(decimal_col) FROM read_avro('__TEST_DIR__/decimal_type.avro') LIMIT 1;
+----
+DECIMAL(19,1)
+
+
+# test different width types
+loop i 2 38
+
+statement ok
+COPY (
+    from values (1.3::DECIMAL(${i},1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+1.3
+NULL
+
+
+# check sign extensions on decimal scales > 18
+statement ok
+COPY (
+    from values (-1.3::DECIMAL(${i},1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+
+
+query I
+SELECT decimal_col FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY decimal_col NULLS LAST;
+----
+-1.3
+NULL
+
+endloop
+
+statement ok
+COPY (
+    select dec_9_4, dec_4_1, dec38_10, dec_18_6 from test_all_types()
+) TO '__TEST_DIR__/decimal_type.avro';
+
+query IIII
+SELECT  dec_9_4, dec_4_1, dec38_10, dec_18_6 FROM read_avro('__TEST_DIR__/decimal_type.avro') ORDER BY dec38_10 NULLS LAST;
+----
+-99999.9999	-999.9	-9999999999999999999999999999.9999999999	-999999999999.999999
+99999.9999	999.9	9999999999999999999999999999.9999999999	999999999999.999999
+NULL	NULL	NULL	NULL
+
+# check error on extreme width values > 38
+statement error
+COPY (
+    from values (-1.3::DECIMAL(10000,1)), (NULL) t(decimal_col)
+) TO '__TEST_DIR__/decimal_type.avro';
+----
+<REGEX>:.*DECIMAL type width must be between 1 and 38.*
+

--- a/test/sql/copy/test_temporal_types.test
+++ b/test/sql/copy/test_temporal_types.test
@@ -100,6 +100,24 @@ SELECT tstz_col FROM read_avro('__TEST_DIR__/timestamptz_type.avro') ORDER BY ts
 2024-01-15 12:34:56+01
 NULL
 
+# Test Timestamp NS
+
+statement ok
+COPY (
+	select timestamp_ns '1992-01-01 11:30:00.123456789' a
+) TO '__TEST_DIR__/timestamp_ns.avro' (FORMAT AVRO);
+
+query I
+from read_avro('__TEST_DIR__/timestamp_ns.avro')
+----
+1992-01-01 11:30:00.123456789
+
+
+query I
+select column_type from (describe (from read_avro('__TEST_DIR__/timestamp_ns.avro')));
+----
+TIMESTAMP_NS
+
 # ---- All temporal types together, including NULLs ----
 
 statement ok
@@ -111,25 +129,27 @@ COPY (
         '2024-01-15'::DATE        AS date_col,
         '12:34:56'::TIME          AS time_col,
         '2024-01-15 12:34:56'::TIMESTAMP    AS ts_col,
-        '2024-01-15 12:34:56+00'::TIMESTAMPTZ AS tstz_col
+        '2024-01-15 12:34:56+00'::TIMESTAMPTZ AS tstz_col,
+		'2023-01-15 12:12:12.123456789'::TIMESTAMP_NS as ts_ns_col
     UNION ALL
     SELECT
         NULL::DATE,
         NULL::TIME,
         NULL::TIMESTAMP,
-        NULL::TIMESTAMPTZ
+        NULL::TIMESTAMPTZ,
+		NULL::TIMESTAMP_NS
 ) TO '__TEST_DIR__/all_temporal_types.avro';
 
-query IIII
-SELECT typeof(date_col), typeof(time_col), typeof(ts_col), typeof(tstz_col)
+query IIIII
+SELECT typeof(date_col), typeof(time_col), typeof(ts_col), typeof(tstz_col), typeof(ts_ns_col)
 FROM read_avro('__TEST_DIR__/all_temporal_types.avro')
 LIMIT 1;
 ----
-DATE	TIME	TIMESTAMP	TIMESTAMP WITH TIME ZONE
+DATE	TIME	TIMESTAMP	TIMESTAMP WITH TIME ZONE	TIMESTAMP_NS
 
-query IIII
+query IIIII
 SELECT * FROM read_avro('__TEST_DIR__/all_temporal_types.avro')
 ORDER BY date_col NULLS LAST;
 ----
-2024-01-15	12:34:56	2024-01-15 12:34:56	2024-01-15 12:34:56+00
-NULL	NULL	NULL	NULL
+2024-01-15	12:34:56	2024-01-15 12:34:56	2024-01-15 12:34:56+00	2023-01-15 12:12:12.123456789
+NULL	NULL	NULL	NULL	NULL

--- a/test/sql/copy/test_temporal_types.test
+++ b/test/sql/copy/test_temporal_types.test
@@ -1,0 +1,135 @@
+# name: test/sql/copy/test_temporal_types.test
+# group: [copy]
+
+require avro
+
+require icu
+
+# ---- DATE ----
+
+statement ok
+COPY (
+    from values ('2024-01-15'::DATE), (NULL) t(date_col)
+) TO '__TEST_DIR__/date_type.avro';
+
+query I
+SELECT typeof(date_col) FROM read_avro('/Users/tomebergen/git/duckdb-avro/date_type.avro') LIMIT 1;
+----
+DATE
+
+query I
+SELECT date_col FROM read_avro('__TEST_DIR__/date_type.avro') ORDER BY date_col NULLS LAST;
+----
+2024-01-15
+NULL
+
+# ---- TIME ----
+
+statement ok
+COPY (
+    from values ('12:34:56'::TIME), (NULL) t(time_col)
+) TO '__TEST_DIR__/time_type.avro';
+
+query I
+SELECT typeof(time_col) FROM read_avro('__TEST_DIR__/time_type.avro') LIMIT 1;
+----
+TIME
+
+query I
+SELECT time_col FROM read_avro('__TEST_DIR__/time_type.avro') ORDER BY time_col NULLS LAST;
+----
+12:34:56
+NULL
+
+# ---- TIMESTAMP ----
+
+statement ok
+COPY (
+    FROM VALUES ('2024-01-15 12:34:56'::TIMESTAMP), (NULL) t(ts_col)
+) TO '__TEST_DIR__/timestamp_type.avro';
+
+query I
+SELECT typeof(ts_col) FROM read_avro('__TEST_DIR__/timestamp_type.avro') LIMIT 1;
+----
+TIMESTAMP
+
+query I
+SELECT ts_col FROM read_avro('__TEST_DIR__/timestamp_type.avro') ORDER BY ts_col NULLS LAST;
+----
+2024-01-15 12:34:56
+NULL
+
+# ---- TIMESTAMP WITH TIME ZONE ----
+
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+COPY (
+    FROM VALUES ('2024-01-15 12:34:56+00'::TIMESTAMPTZ), (NULL)  t(tstz_col)
+) TO '__TEST_DIR__/timestamptz_type.avro';
+
+query I
+SELECT typeof(tstz_col) FROM read_avro('__TEST_DIR__/timestamptz_type.avro') LIMIT 1;
+----
+TIMESTAMP WITH TIME ZONE
+
+query I
+SELECT tstz_col FROM read_avro('__TEST_DIR__/timestamptz_type.avro') ORDER BY tstz_col NULLS LAST;
+----
+2024-01-15 12:34:56+00
+NULL
+
+statement ok
+SET TimeZone = 'CET';
+
+statement ok
+COPY (
+    FROM VALUES ('2024-01-15 12:34:56'::TIMESTAMPTZ), (NULL)  t(tstz_col)
+) TO '__TEST_DIR__/timestamptz_type.avro';
+
+query I
+    SELECT typeof(tstz_col) FROM read_avro('__TEST_DIR__/timestamptz_type.avro') LIMIT 1;
+----
+TIMESTAMP WITH TIME ZONE
+
+# we get the same value back with the correct timezone info (+1 for CET)
+query I
+SELECT tstz_col FROM read_avro('__TEST_DIR__/timestamptz_type.avro') ORDER BY tstz_col NULLS LAST;
+----
+2024-01-15 12:34:56+01
+NULL
+
+# ---- All temporal types together, including NULLs ----
+
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+COPY (
+    SELECT
+        '2024-01-15'::DATE        AS date_col,
+        '12:34:56'::TIME          AS time_col,
+        '2024-01-15 12:34:56'::TIMESTAMP    AS ts_col,
+        '2024-01-15 12:34:56+00'::TIMESTAMPTZ AS tstz_col
+    UNION ALL
+    SELECT
+        NULL::DATE,
+        NULL::TIME,
+        NULL::TIMESTAMP,
+        NULL::TIMESTAMPTZ
+) TO '__TEST_DIR__/all_temporal_types.avro';
+
+query IIII
+SELECT typeof(date_col), typeof(time_col), typeof(ts_col), typeof(tstz_col)
+FROM read_avro('__TEST_DIR__/all_temporal_types.avro')
+LIMIT 1;
+----
+DATE	TIME	TIMESTAMP	TIMESTAMP WITH TIME ZONE
+
+query IIII
+SELECT * FROM read_avro('__TEST_DIR__/all_temporal_types.avro')
+ORDER BY date_col NULLS LAST;
+----
+2024-01-15	12:34:56	2024-01-15 12:34:56	2024-01-15 12:34:56+00
+NULL	NULL	NULL	NULL

--- a/test/sql/copy/test_uuid_type.test
+++ b/test/sql/copy/test_uuid_type.test
@@ -1,0 +1,29 @@
+# name: test/sql/copy/test_uuid_type.test
+# group: [copy]
+
+require avro
+
+require icu
+
+# ---- DATE ----
+
+statement ok
+create table uuid as from values (UUID()::UUID), (NULL) t(uuid_col);
+
+statement ok
+COPY (
+    from uuid
+) TO '__TEST_DIR__/uuid_type.avro';
+
+query I
+SELECT typeof(uuid_col) FROM read_avro('__TEST_DIR__/uuid_type.avro') LIMIT 1;
+----
+UUID
+
+query I nosort result_file
+SELECT uuid_col FROM read_avro('__TEST_DIR__/uuid_type.avro') ORDER BY uuid_col NULLS LAST;
+----
+
+query I nosort result_file
+select * from uuid;
+----

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,19 +1,19 @@
 {
-	"dependencies": [
-		"avro-c"
-	],
-	"vcpkg-configuration": {
-		"registries": [
-			{
-				"kind": "git",
-				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
-				"baseline": "0f82f5a9bbd58ef21110c97238855ba1829dc343",
-				"packages": [
-					"vcpkg-cmake",
-					"avro-c"
-				]
-			}
-		]
-	},
-	"builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+  "dependencies": [
+    "avro-c"
+  ],
+  "vcpkg-configuration": {
+    "registries": [
+      {
+        "kind": "git",
+        "repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
+        "baseline": "319077d124a1715e8304dc7167e93605b04f029c",
+        "packages": [
+          "vcpkg-cmake",
+          "avro-c"
+        ]
+      }
+    ]
+  },
+  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,8 +6,8 @@
 		"registries": [
 			{
 				"kind": "git",
-				"repository": "https://github.com/Tmonster/vcpkg-duckdb-ports",
-				"baseline": "4d55d0708a5956af331733c3e13991d9d9b8dae4",
+				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
+				"baseline": "0f82f5a9bbd58ef21110c97238855ba1829dc343",
 				"packages": [
 					"vcpkg-cmake",
 					"avro-c"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,8 +6,8 @@
 		"registries": [
 			{
 				"kind": "git",
-				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
-				"baseline": "02558971ebafdbaa697a0704a3ed7ba365cd5495",
+				"repository": "https://github.com/Tmonster/vcpkg-duckdb-ports",
+				"baseline": "a44299009d89462aa7a0b8ff1e8b41978a385593",
 				"packages": [
 					"vcpkg-cmake",
 					"avro-c"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
 			{
 				"kind": "git",
 				"repository": "https://github.com/Tmonster/vcpkg-duckdb-ports",
-				"baseline": "a44299009d89462aa7a0b8ff1e8b41978a385593",
+				"baseline": "4d55d0708a5956af331733c3e13991d9d9b8dae4",
 				"packages": [
 					"vcpkg-cmake",
 					"avro-c"


### PR DESCRIPTION
Most of the features added here are for supporting avro types for iceberg (see https://iceberg.apache.org/spec/#appendix-a-format-specific-requirements)