### PR TITLE
Fix AvroReader::Read reading iceberg metadata sigsegv

### DIFF
--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -555,6 +555,7 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
 }
 
 void AvroReader::Read(DataChunk &output) {
+	read_vec = make_uniq<Vector>(duckdb_type);
 	idx_t out_idx = 0;
 
 	while (avro_file_reader_read_value(reader, &value) == 0) {


### PR DESCRIPTION
# SIGSEGV in `AvroReader::Read` when reading Avro files with LIST/MAP columns across multiple batches

## Summary

`AvroReader::Read()` reuses a member variable `read_vec` across batch reads without resetting it. For LIST/MAP columns, the child vector's `list_size` accumulates across batches. When downstream code (e.g. `RemapStructFunction` in DuckDB core) reads this inflated `list_size` and passes it to `ListVector::Reserve` on a freshly allocated result vector, `Vector::Resize` performs a `memcpy` on invalid memory, causing a segmentation fault.

The bug is triggered when reading Iceberg manifest files via `iceberg_metadata()`, where the Iceberg extension's `BY_FIELD_ID` column mapping produces a `remap_struct` expression that exposes the accumulated `list_size`. Any Iceberg table with more than 2048 manifest entries (DuckDB's `STANDARD_VECTOR_SIZE`) and MAP-typed manifest fields (e.g. `column_sizes`, `value_counts`) will crash.

## Environment

- DuckDB v1.5.1
- Avro extension v1.5.1
- Iceberg extension v1.5.1
- Platform: Linux x86_64

## Steps to reproduce

### Option A: Self-contained reproduction script

**Prerequisites:** Python 3 with `avro` package (`pip install avro`).

**1. Generate a minimal Iceberg table (Python script):**

```python
import avro.schema
from avro.datafile import DataFileWriter
from avro.io import DatumWriter
import json, os

TABLE_DIR = "iceberg_test_table"
META_DIR = os.path.join(TABLE_DIR, "metadata")
DATA_DIR = os.path.join(TABLE_DIR, "data")
os.makedirs(META_DIR, exist_ok=True)
os.makedirs(DATA_DIR, exist_ok=True)

NUM_ENTRIES = 10000  # must exceed STANDARD_VECTOR_SIZE (2048)

manifest_entry_schema = json.dumps({
    "type": "record",
    "name": "manifest_entry",
    "fields": [
        {"name": "status", "type": "int", "field-id": 0},
        {"name": "snapshot_id", "type": ["null", "long"], "default": None, "field-id": 1},
        {"name": "sequence_number", "type": ["null", "long"], "default": None, "field-id": 3},
        {"name": "file_sequence_number", "type": ["null", "long"], "default": None, "field-id": 4},
        {"name": "data_file", "type": {
            "type": "record", "name": "r2",
            "fields": [
                {"name": "content", "type": "int", "default": 0, "field-id": 134},
                {"name": "file_path", "type": "string", "field-id": 100},
                {"name": "file_format", "type": "string", "field-id": 101},
                {"name": "partition", "type": {"type": "record", "name": "r102", "fields": []}, "field-id": 102},
                {"name": "record_count", "type": "long", "field-id": 103},
                {"name": "file_size_in_bytes", "type": "long", "field-id": 104},
                {"name": "column_sizes", "type": ["null", {
                    "type": "array",
                    "items": {"type": "record", "name": "k117_v118", "fields": [
                        {"name": "key", "type": "int", "field-id": 117},
                        {"name": "value", "type": "long", "field-id": 118}
                    ]}, "logicalType": "map"
                }], "default": None, "field-id": 108},
                {"name": "value_counts", "type": ["null", {
                    "type": "array",
                    "items": {"type": "record", "name": "k119_v120", "fields": [
                        {"name": "key", "type": "int", "field-id": 119},
                        {"name": "value", "type": "long", "field-id": 120}
                    ]}, "logicalType": "map"
                }], "default": None, "field-id": 109},
                {"name": "null_value_counts", "type": ["null", {
                    "type": "array",
                    "items": {"type": "record", "name": "k121_v122", "fields": [
                        {"name": "key", "type": "int", "field-id": 121},
                        {"name": "value", "type": "long", "field-id": 122}
                    ]}, "logicalType": "map"
                }], "default": None, "field-id": 110},
                {"name": "nan_value_counts", "type": ["null", {
                    "type": "array",
                    "items": {"type": "record", "name": "k138_v139", "fields": [
                        {"name": "key", "type": "int", "field-id": 138},
                        {"name": "value", "type": "long", "field-id": 139}
                    ]}, "logicalType": "map"
                }], "default": None, "field-id": 137},
                {"name": "lower_bounds", "type": ["null", {
                    "type": "array",
                    "items": {"type": "record", "name": "k126_v127", "fields": [
                        {"name": "key", "type": "int", "field-id": 126},
                        {"name": "value", "type": "bytes", "field-id": 127}
                    ]}, "logicalType": "map"
                }], "default": None, "field-id": 125},
                {"name": "upper_bounds", "type": ["null", {
                    "type": "array",
                    "items": {"type": "record", "name": "k129_v130", "fields": [
                        {"name": "key", "type": "int", "field-id": 129},
                        {"name": "value", "type": "bytes", "field-id": 130}
                    ]}, "logicalType": "map"
                }], "default": None, "field-id": 128},
                {"name": "key_metadata", "type": ["null", "bytes"], "default": None, "field-id": 131},
                {"name": "split_offsets", "type": ["null", {
                    "type": "array", "items": "long", "element-id": 133
                }], "default": None, "field-id": 132},
                {"name": "equality_ids", "type": ["null", {
                    "type": "array", "items": "int", "element-id": 136
                }], "default": None, "field-id": 135},
                {"name": "sort_order_id", "type": ["null", "int"], "default": None, "field-id": 140},
            ]
        }, "field-id": 2}
    ]
})

manifest_path = os.path.join(META_DIR, "manifest-m0.avro")
schema = avro.schema.parse(manifest_entry_schema)
writer = DataFileWriter(open(manifest_path, "wb"), DatumWriter(), schema)
for i in range(NUM_ENTRIES):
    writer.append({
        "status": 1, "snapshot_id": 1000000, "sequence_number": 1, "file_sequence_number": 1,
        "data_file": {
            "content": 0,
            "file_path": os.path.join(DATA_DIR, f"data_{i:05d}.parquet"),
            "file_format": "PARQUET",
            "partition": {},
            "record_count": 1000,
            "file_size_in_bytes": 50000,
            "column_sizes": [{"key": c, "value": 1000 + i * 10 + c} for c in range(1, 21)],
            "value_counts": [{"key": c, "value": 500 + i} for c in range(1, 21)],
            "null_value_counts": [{"key": c, "value": i % 50} for c in range(1, 21)],
            "nan_value_counts": None, "lower_bounds": None, "upper_bounds": None,
            "key_metadata": None, "split_offsets": None, "equality_ids": None, "sort_order_id": 0,
        }
    })
writer.close()

manifest_list_schema = json.dumps({
    "type": "record", "name": "manifest_file",
    "fields": [
        {"name": "manifest_path", "type": "string", "field-id": 500},
        {"name": "manifest_length", "type": "long", "field-id": 501},
        {"name": "partition_spec_id", "type": "int", "field-id": 502},
        {"name": "content", "type": "int", "field-id": 517},
        {"name": "sequence_number", "type": "long", "field-id": 515},
        {"name": "min_sequence_number", "type": "long", "field-id": 516},
        {"name": "added_snapshot_id", "type": "long", "field-id": 503},
        {"name": "added_files_count", "type": "int", "field-id": 504},
        {"name": "existing_files_count", "type": "int", "field-id": 505},
        {"name": "deleted_files_count", "type": "int", "field-id": 506},
        {"name": "added_rows_count", "type": "long", "field-id": 512},
        {"name": "existing_rows_count", "type": "long", "field-id": 513},
        {"name": "deleted_rows_count", "type": "long", "field-id": 514},
        {"name": "partitions", "type": ["null", {
            "type": "array",
            "items": {"type": "record", "name": "r508", "fields": [
                {"name": "contains_null", "type": "boolean", "field-id": 509},
                {"name": "contains_nan", "type": ["null", "boolean"], "default": None, "field-id": 518},
                {"name": "lower_bound", "type": ["null", "bytes"], "default": None, "field-id": 510},
                {"name": "upper_bound", "type": ["null", "bytes"], "default": None, "field-id": 511}
            ]}, "element-id": 508
        }], "default": None, "field-id": 507},
    ]
})

snap_path = os.path.join(META_DIR, "snap-1000000-0-test.avro")
snap_schema = avro.schema.parse(manifest_list_schema)
writer = DataFileWriter(open(snap_path, "wb"), DatumWriter(), snap_schema)
writer.append({
    "manifest_path": manifest_path, "manifest_length": os.path.getsize(manifest_path),
    "partition_spec_id": 0, "content": 0, "sequence_number": 1, "min_sequence_number": 1,
    "added_snapshot_id": 1000000, "added_files_count": NUM_ENTRIES,
    "existing_files_count": 0, "deleted_files_count": 0,
    "added_rows_count": NUM_ENTRIES * 1000, "existing_rows_count": 0, "deleted_rows_count": 0,
    "partitions": None,
})
writer.close()

metadata = {
    "format-version": 2,
    "table-uuid": "test-uuid-0000-0000-000000000000",
    "location": os.path.abspath(TABLE_DIR),
    "last-sequence-number": 1, "last-updated-ms": 1700000000000, "last-column-id": 3,
    "schemas": [{"schema-id": 0, "type": "struct", "fields": [
        {"id": 1, "name": "id", "required": False, "type": "int"},
        {"id": 2, "name": "name", "required": False, "type": "string"},
        {"id": 3, "name": "value", "required": False, "type": "long"}
    ]}],
    "current-schema-id": 0,
    "partition-specs": [{"spec-id": 0, "fields": []}], "default-spec-id": 0, "last-partition-id": 999,
    "properties": {}, "current-snapshot-id": 1000000,
    "snapshots": [{"snapshot-id": 1000000, "sequence-number": 1, "timestamp-ms": 1700000000000,
        "manifest-list": os.path.abspath(snap_path),
        "summary": {"operation": "append", "added-data-files": str(NUM_ENTRIES),
            "total-data-files": str(NUM_ENTRIES), "added-records": str(NUM_ENTRIES * 1000),
            "total-records": str(NUM_ENTRIES * 1000)},
        "schema-id": 0}],
    "snapshot-log": [{"snapshot-id": 1000000, "timestamp-ms": 1700000000000}],
    "metadata-log": [], "sort-orders": [{"order-id": 0, "fields": []}],
    "default-sort-order-id": 0, "refs": {"main": {"snapshot-id": 1000000, "type": "branch"}}
}
with open(os.path.join(META_DIR, "v1.metadata.json"), "w") as f:
    json.dump(metadata, f, indent=2)
with open(os.path.join(META_DIR, "version-hint.text"), "w") as f:
    f.write("1")
```

**2. Trigger the crash:**

```sql
-- This crashes with SIGSEGV
SELECT count(*) FROM iceberg_metadata('iceberg_test_table/metadata/v1.metadata.json');
```

### Option B: Any real-world Iceberg table

Any Iceberg table whose manifest file contains more than 2048 entries will crash when queried via `iceberg_metadata()`.

## Crash backtrace

```
#0  __memmove_avx512_unaligned_erms ()
#1  duckdb::Vector::Resize(unsigned long, unsigned long)
#2  duckdb::VectorListBuffer::Reserve(unsigned long)
#3  duckdb::RemapNested(...)      -- RemapMap/RemapList
#4  duckdb::RemapChildVectors(...)
#5  duckdb::RemapNested(...)      -- RemapStruct (outer)
#6  duckdb::RemapStructFunction(DataChunk&, ExpressionState&, Vector&)
#7  duckdb::ExpressionExecutor::Execute(...)
#8  ...
#9  duckdb::MultiFileReader::FinalizeChunk(...)
#10 duckdb::IcebergAvroMultiFileReader::FinalizeChunk(...)
#11 duckdb::MultiFileFunction<AvroMultiFileInfo>::MultiFileScan(...)
#12 duckdb::BaseManifestReader::ScanInternal(...)
```

## Root cause

### `read_vec` persists across batches

`AvroReader::read_vec` is a member variable that lives for the entire lifetime of the reader. `AvroReader::Read()` is called once per batch (up to `STANDARD_VECTOR_SIZE = 2048` rows), but `read_vec` is never reset between calls:

```cpp
// avro_reader.cpp (before fix)
void AvroReader::Read(DataChunk &output) {
    // read_vec is NOT reset here
    idx_t out_idx = 0;
    while (avro_file_reader_read_value(reader, &value) == 0) {
        TransformValue(&value, avro_type, *read_vec, out_idx++);
        if (out_idx == STANDARD_VECTOR_SIZE) break;
    }
    // output references read_vec's children
    output.data[col_idx].Reference(
        *StructVector::GetEntries(*read_vec)[...]);
}
```

### LIST/MAP child data accumulates

`TransformValue` handles LIST and MAP types by *appending* to the child vector:

```cpp
// avro_reader.cpp:504-548
case LogicalTypeId::MAP:
case LogicalTypeId::LIST: {
    auto child_offset = ListVector::GetListSize(target);   // previous batch's total
    ListVector::Reserve(target, child_offset + list_len);
    // ... append child elements at child_offset ...
    ListVector::SetListSize(target, child_offset + list_len);  // grows every batch
}
```

The top-level `list_entry_t` values (offset/length) are written at `out_idx` which resets to 0 each batch, so they get overwritten correctly. But the *child vector* data and `list_size` never reset — they accumulate:

| Batch | Rows | `list_size` at end (3 MAP fields × 20 entries each) |
|-------|------|-----------------------------------------------------|
| 1     | 0–2047 | 122,880 |
| 2     | 2048–4095 | 245,760 |
| 3     | 4096–6143 | 368,640 |
| ...   | ... | ... |
| 5     | 8192–9999 | ~600,000 |

### `RemapStructFunction` reads the inflated `list_size`

The Iceberg extension reads manifest Avro files using `BY_FIELD_ID` column mapping. Because the Avro schema's field order differs from the Iceberg table schema, DuckDB's `MultiFileReader` generates a `remap_struct` expression. During `FinalizeChunk`, this expression evaluates `RemapMap` on each MAP child of the `data_file` struct:

```cpp
// remap_struct.cpp (DuckDB core)
void RemapMap(Vector &input, ..., Vector &result, idx_t result_size, ...) {
    auto list_size = ListVector::GetListSize(input);  // reads accumulated value (e.g. 600,000)
    ListVector::Reserve(result, list_size);             // result is freshly allocated with capacity 2048
    ListVector::SetListSize(result, list_size);
    // ...
}
```

`ListVector::Reserve` calls `VectorListBuffer::Reserve`, which calls `Vector::Resize(2048, next_power_of_two(600000))`. Inside `Resize`, `memcpy` is called to copy `2048 * type_size` bytes from the old buffer — but the buffer state is inconsistent with the claimed capacity, causing a read from invalid memory → **SIGSEGV**.

### Why it only crashes through Iceberg, not plain `read_avro`

Plain `read_avro` with glob (even with `RemapStructFunction` active) does not crash because the query engine consumes vectors through `list_entry_t` offset/length pairs that only reference the current batch's subset of the accumulated child data. No operation attempts to `Reserve` based on the full `list_size`.

The Iceberg path crashes because `BaseManifestReader::ScanInternal` additionally calls `vec.Flatten(count)` on the output chunk after scanning, and the `remap_struct` expression produces a result vector whose MAP children claim to have `list_size` entries but whose backing buffers are not sized accordingly.

## Fix

Reset `read_vec` at the beginning of each `Read()` call to prevent cross-batch accumulation:

```diff
 void AvroReader::Read(DataChunk &output) {
+    read_vec = make_uniq<Vector>(duckdb_type);
     idx_t out_idx = 0;
 
     while (avro_file_reader_read_value(reader, &value) == 0) {
```

This ensures each batch starts with `list_size = 0`, so `RemapMap`/`RemapList` reads only the current batch's actual child count.
