### PR TITLE
Close file handle in WriteAvroFinalize (fixes 0-byte avro on Azure DFS / OneLake)

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -846,7 +846,15 @@ static void WriteAvroCombine(ExecutionContext &context, FunctionData &bind_data,
 }
 
 static void WriteAvroFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
-	return;
+	auto &global_state = gstate.Cast<WriteAvroGlobalState>();
+	//! WriteAvroSink has already flushed every block to the file handle, so there is no
+	//! more data to write here. We only need to close the handle, which is required for
+	//! stores that commit on Close() (e.g. Azure DFS / OneLake, where Write() Appends
+	//! staged bytes that only become visible after Flush(Close=true)). Local FS, S3, and
+	//! Azure Blob are unaffected because their writes commit incrementally.
+	if (global_state.handle) {
+		global_state.handle->Close();
+	}
 }
 
 CopyFunctionExecutionMode WriteAvroExecutionMode(bool preserve_insertion_order, bool supports_batch_index) {


### PR DESCRIPTION
## Problem

When writing iceberg metadata through duckdb-iceberg's REST catalog backed by Microsoft Fabric / OneLake (Azure DFS / ADLS Gen2), the avro manifest and manifest-list files end up **0 bytes** in storage. The catalog then commits snapshots pointing at empty manifest files, breaking subsequent reads.

Reported in duckdb/duckdb-iceberg#966.

## Root cause

`WriteAvroFinalize` is a no-op. The `FileHandle` is only released when the `unique_ptr` in `WriteAvroGlobalState` is destroyed.

For most storage backends that's fine — `Write()` commits incrementally. But `AzureDfsStorageFileSystem::Write` calls `file_client.Append(...)`, which **stages** bytes that only become visible after `Flush(Close=true)`. That `Flush` is reached via `AzureDfsStorageFileHandle::Close() -> Sync(true) -> file_client.Flush(..., Close=true)`. The base `FileHandle` destructor doesn't call `Close()`, so on Azure DFS the appended bytes are silently dropped.

Parquet/JSON/CSV writers don't hit this because their finalizers explicitly close the handle. Local FS, S3, and Azure Blob also commit their writes incrementally, so they don't see the bug either.

## Fix

`WriteAvroSink` already flushes each block to the handle via `WriteData`, so `Finalize` doesn't need to write any more data — it only needs to close the handle so DFS stores get the `Flush(Close=true)`.

Net change: 9 lines.

## Testing

I do **not** have the Azure DFS / OneLake CI infrastructure to add a regression test in this repo. I tested manually with the artifact built by this branch's CI run:

- duckdb 1.4.4, linux_amd64, with this avro extension built against v1.4.4
- duckdb-iceberg from `core_nightly`, ATTACH'd to a OneLake-hosted iceberg REST catalog
- `CREATE TABLE ... AS SELECT ... LIMIT 0` followed by `INSERT INTO ... BY NAME SELECT ...`

**Before:** manifest avro files were 0 bytes, snapshot commit succeeded but reads were broken (see screenshot in linked issue).
**After:** manifest avro files contain valid avro data; subsequent scans work.

<!-- @djouallah: please attach the post-fix screenshot here, e.g.

![non-zero avro after fix](https://user-images.githubusercontent.com/...)

so reviewers see it next to the original 0-byte screenshot in #966. -->

## Disclosure

This patch was drafted with AI assistance (Claude Code), but the diagnosis was verified by reading `duckdb-azure`'s `AzureDfsStorageFileHandle::{Sync,Close,Write}`, and I confirmed end-to-end that the fix resolves the OneLake symptom on real Fabric storage. An earlier draft of the patch over-flushed and doubled rows; the current one-liner is what shipped past the existing test suite (`empty_struct.test`, `duplicate_name.test`, `nullable.test` and friends — all green on the fork CI run).

## Backport

Same `Finalize` no-op exists on `v1.4-andium`; happy to open a backport PR there once this lands. That's the line currently consumed by duckdb-iceberg `v1.4-andium` (1.4.4 release line).