### PR TITLE
Read millis by default

### DIFF
--- a/src/avro_extension.cpp
+++ b/src/avro_extension.cpp
@@ -20,7 +20,6 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Register a scalar function
 	auto table_function = MultiFileFunction<AvroMultiFileInfo>("read_avro");
 	table_function.projection_pushdown = true;
-	table_function.named_parameters["convert_millis_to_micro"] = LogicalType::BOOLEAN;
 	loader.RegisterFunction(MultiFileReader::CreateFunctionSet(table_function));
 	loader.RegisterFunction(AvroCopyFunction::Create());
 }

--- a/src/avro_multi_file_info.cpp
+++ b/src/avro_multi_file_info.cpp
@@ -1,6 +1,5 @@
 #include "avro_multi_file_info.hpp"
 #include "avro_reader.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
@@ -23,12 +22,6 @@ bool AvroMultiFileInfo::ParseCopyOption(ClientContext &context, const string &ke
 
 bool AvroMultiFileInfo::ParseOption(ClientContext &context, const string &key, const Value &val,
                                     MultiFileOptions &file_options, BaseFileReaderOptions &options) {
-	auto &avro_options = options.Cast<AvroFileReaderOptions>();
-	auto loption = StringUtil::Lower(key);
-	if (loption == "convert_millis_to_micro") {
-		avro_options.convert_millis_to_micro = BooleanValue::Get(val.DefaultCastAs(LogicalType::BOOLEAN));
-		return true;
-	}
 	return false;
 }
 

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -9,7 +9,7 @@
 
 namespace duckdb {
 
-static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema, bool convert_millis_to_micro) {
+static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema) {
 	auto logical_type_raw = avro_schema_logical_type(avro_schema);
 	if (!logical_type_raw) {
 		return LogicalType::INVALID;
@@ -59,17 +59,9 @@ static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema, bool
 		return LogicalType::UUID;
 	}
 	if (logical_type == "time-millis") {
-		if (!convert_millis_to_micro) {
-			throw NotImplementedException("Avro logical type time-millis not supported. Use "
-			                              "convert_millis_to_micro=true to automatically convert to microseconds");
-		}
 		return LogicalType::TIME;
 	}
 	if (logical_type == "timestamp-millis") {
-		if (!convert_millis_to_micro) {
-			throw NotImplementedException("Avro logical type timestamp-millis not supported. Use "
-			                              "convert_millis_to_micro=true to automatically convert to microseconds");
-		}
 		auto adjust_to_utc = avro_schema_adjust_to_utc(avro_schema);
 		if (adjust_to_utc > 0) {
 			return LogicalType::TIMESTAMP_TZ;
@@ -77,18 +69,13 @@ static LogicalType AvroLogicalTypeToLogicalType(avro_schema_t &avro_schema, bool
 		return LogicalType::TIMESTAMP;
 	}
 	if (logical_type == "local-timestamp-millis") {
-		if (!convert_millis_to_micro) {
-			throw NotImplementedException("Avro logical type local-timestamp-millis not supported. Use "
-			                              "convert_millis_to_micro=true to automatically convert to microseconds");
-		}
 		return LogicalType::TIMESTAMP;
 	}
 	throw NotImplementedException("Unknown Avro logical type %s", logical_type);
 }
 
-static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string> parent_schema_names,
-                                bool convert_millis_to_micro) {
-	auto duckdb_logical_type = AvroLogicalTypeToLogicalType(avro_schema, convert_millis_to_micro);
+static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string> parent_schema_names) {
+	auto duckdb_logical_type = AvroLogicalTypeToLogicalType(avro_schema);
 	bool has_logical_type = duckdb_logical_type != LogicalType::INVALID;
 
 	auto raw_lt = avro_schema_logical_type(avro_schema);
@@ -125,7 +112,7 @@ static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string
 		unordered_map<idx_t, optional_idx> union_child_map;
 		for (idx_t child_idx = 0; child_idx < num_children; child_idx++) {
 			auto child_schema = avro_schema_union_branch(avro_schema, child_idx);
-			auto child_type = TransformSchema(child_schema, parent_schema_names, convert_millis_to_micro);
+			auto child_type = TransformSchema(child_schema, parent_schema_names);
 			union_children.push_back(
 			    std::pair<std::string, AvroType>(StringUtil::Format("u%llu", child_idx), std::move(child_type)));
 			if (child_type.duckdb_type.id() != LogicalTypeId::SQLNULL) {
@@ -150,7 +137,7 @@ static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string
 		child_list_t<AvroType> struct_children;
 		for (idx_t child_idx = 0; child_idx < num_children; child_idx++) {
 			auto child_schema = avro_schema_record_field_get_by_index(avro_schema, child_idx);
-			auto child_type = TransformSchema(child_schema, parent_schema_names, convert_millis_to_micro);
+			auto child_type = TransformSchema(child_schema, parent_schema_names);
 			child_type.field_id = avro_schema_record_field_id(avro_schema, child_idx);
 			auto child_name = avro_schema_record_field_name(avro_schema, child_idx);
 			if (!child_name || strlen(child_name) == 0) {
@@ -178,7 +165,7 @@ static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string
 	case AVRO_ARRAY: {
 		auto child_schema = avro_schema_array_items(avro_schema);
 		auto element_id = avro_schema_array_element_id(avro_schema);
-		auto child_type = TransformSchema(child_schema, parent_schema_names, convert_millis_to_micro);
+		auto child_type = TransformSchema(child_schema, parent_schema_names);
 		child_type.field_id = element_id;
 		child_list_t<AvroType> list_children;
 		list_children.push_back(std::pair<std::string, AvroType>("list_entry", std::move(child_type)));
@@ -195,7 +182,7 @@ static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string
 
 		AvroType key_type(AVRO_STRING, LogicalTypeId::VARCHAR);
 		key_type.field_id = key_id;
-		auto value_type = TransformSchema(child_schema, parent_schema_names, convert_millis_to_micro);
+		auto value_type = TransformSchema(child_schema, parent_schema_names);
 		value_type.field_id = value_id;
 
 		child_list_t<AvroType> map_children;
@@ -205,7 +192,7 @@ static AvroType TransformSchema(avro_schema_t &avro_schema, unordered_set<string
 	}
 	case AVRO_LINK: {
 		auto target = avro_schema_link_target(avro_schema);
-		return TransformSchema(target, parent_schema_names, convert_millis_to_micro);
+		return TransformSchema(target, parent_schema_names);
 	}
 	default:
 		throw NotImplementedException("Unknown Avro Type %s", avro_schema_type_name(avro_schema));
@@ -235,7 +222,7 @@ AvroReader::AvroReader(ClientContext &context, OpenFileInfo file, const AvroFile
 	auto schema_name = avro_schema_name(avro_schema);
 	string root_name = schema_name ? schema_name : "avro_schema";
 
-	avro_type = TransformSchema(avro_schema, {}, options.convert_millis_to_micro);
+	avro_type = TransformSchema(avro_schema, {});
 	auto root = AvroType::TransformAvroType(root_name, avro_type);
 	duckdb_type = root.type;
 	read_chunk.Initialize(context, {duckdb_type}, STANDARD_VECTOR_SIZE);

--- a/src/include/avro_multi_file_info.hpp
+++ b/src/include/avro_multi_file_info.hpp
@@ -12,10 +12,7 @@
 
 namespace duckdb {
 
-class AvroFileReaderOptions : public BaseFileReaderOptions {
-public:
-	bool convert_millis_to_micro = false;
-};
+class AvroFileReaderOptions : public BaseFileReaderOptions {};
 
 struct AvroMultiFileInfo : MultiFileReaderInterface {
 	static unique_ptr<MultiFileReaderInterface> CreateInterface(ClientContext &context);

--- a/test/sql/read_avro_millis.test
+++ b/test/sql/read_avro_millis.test
@@ -12,21 +12,13 @@ SET TimeZone = 'CET';
 statement ok
 PRAGMA enable_verification
 
-# without the option, timestamp-millis should produce a helpful error
-statement error
-SELECT * FROM read_avro('test/timestamp_millis.avro');
-----
-convert_millis_to_micro=true
-
-# with the option, timestamps are returned as TIMESTAMP (microseconds)
 query I
-SELECT column_type FROM (DESCRIBE FROM read_avro('test/timestamp_millis.avro', convert_millis_to_micro=true)) WHERE column_name = 'ts';
+SELECT column_type FROM (DESCRIBE FROM read_avro('test/timestamp_millis.avro')) WHERE column_name = 'ts';
 ----
 TIMESTAMP
 
-# millisecond values are correctly scaled to microseconds
 query I
-SELECT ts FROM read_avro('test/timestamp_millis.avro', convert_millis_to_micro=true) order by ts NULLS FIRST;
+SELECT ts FROM read_avro('test/timestamp_millis.avro') order by ts NULLS FIRST;
 ----
 NULL
 0001-01-01 00:00:00
@@ -37,7 +29,7 @@ NULL
 
 
 query I
-SELECT ts from read_avro('test/timestamptz_millis.avro', convert_millis_to_micro=true)  order by ts NULLS FIRST;
+SELECT ts from read_avro('test/timestamptz_millis.avro') order by ts NULLS FIRST;
 ----
 NULL
 0001-01-01 00:17:30+00:17
@@ -48,7 +40,7 @@ NULL
 10000-01-01 00:59:59+01
 
 query I
-SELECT ts from read_avro('test/time_millis.avro', convert_millis_to_micro=true) order by ts NULLS FIRST;
+SELECT ts from read_avro('test/time_millis.avro') order by ts NULLS FIRST;
 ----
 NULL
 00:00:00
@@ -57,7 +49,7 @@ NULL
 
 
 query I
-select ts from read_avro('test/localtimestamp-millis.avro', convert_millis_to_micro=true) order by ts NULLS FIRST;
+select ts from read_avro('test/localtimestamp-millis.avro') order by ts NULLS FIRST;
 ----
 NULL
 0001-12-31 (BC) 22:00:00
@@ -65,4 +57,3 @@ NULL
 2023-12-31 12:00:00
 2024-06-15 12:30:45.123
 10000-01-01 04:59:59
-


### PR DESCRIPTION
No need to pass an option I think, DuckDB should just be able to read this and automatically convert the milliseconds to micro seconds.