### PR TITLE
fix: close FileHandle in WriteAvroFinalize so writes commit on remote filesystems

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -402,8 +402,16 @@ WriteAvroLocalState::~WriteAvroLocalState() {
 }
 
 WriteAvroGlobalState::~WriteAvroGlobalState() {
+	//! Cleanup normally happens in WriteAvroFinalize. This is the safety-net path for when
+	//! Finalize wasn't called (e.g. an error occurred during sink). We deliberately do NOT
+	//! Close() the file handle here: the destructor runs in error paths too, and silently
+	//! committing partial output to a remote object store is worse than leaving the (uncommitted)
+	//! handle to be cleaned up by the FS layer.
 	//! NOTE: the 'writer' and 'datum_writer' do not need to be closed, they are owned by the file_writer
-	avro_file_writer_close(file_writer);
+	if (file_writer) {
+		avro_file_writer_close(file_writer);
+		file_writer = nullptr;
+	}
 }
 
 WriteAvroGlobalState::WriteAvroGlobalState(ClientContext &context, FunctionData &bind_data_p, FileSystem &fs,
@@ -640,7 +648,28 @@ static void WriteAvroCombine(ExecutionContext &context, FunctionData &bind_data,
 }
 
 static void WriteAvroFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
-	return;
+	auto &global_state = gstate.Cast<WriteAvroGlobalState>();
+	if (!global_state.file_writer) {
+		return;
+	}
+	//! Closing the avro file writer flushes any data still buffered in the avro library state
+	//! into the in-memory `writer` buffer. WriteAvroSink already drains after every chunk, so
+	//! in practice there's nothing left to write here, but call avro_writer_tell() before
+	//! avro_file_writer_close() because the close frees the writer.
+	auto pending_bytes = avro_writer_tell(global_state.writer);
+	if (pending_bytes > 0) {
+		global_state.WriteData(global_state.memory_buffer.GetData(), pending_bytes);
+	}
+	avro_file_writer_close(global_state.file_writer);
+	global_state.file_writer = nullptr;
+	//! Explicitly close the underlying file handle. Some filesystems (notably ADLS Gen2 via
+	//! abfss://) treat Write() calls as uncommitted appends and only commit on Close()/Sync().
+	//! Without this call the file is left at 0 bytes server-side, and the next reader fails
+	//! parsing it. Mirrors what BufferedFileWriter::Close() (parquet) and CSVWriter::Close()
+	//! do in their finalize paths.
+	if (global_state.handle) {
+		global_state.handle->Close();
+	}
 }
 
 CopyFunctionExecutionMode WriteAvroExecutionMode(bool preserve_insertion_order, bool supports_batch_index) {

--- a/src/include/avro_copy.hpp
+++ b/src/include/avro_copy.hpp
@@ -150,9 +150,9 @@ public:
 	unique_ptr<FileHandle> handle;
 
 	//! The writer for the file
-	avro_writer_t writer;
-	avro_writer_t datum_writer;
-	avro_file_writer_t file_writer;
+	avro_writer_t writer = nullptr;
+	avro_writer_t datum_writer = nullptr;
+	avro_file_writer_t file_writer = nullptr;
 };
 
 struct WriteAvroLocalState : public LocalFunctionData {


### PR DESCRIPTION
## Symptom

`COPY ... TO ... (FORMAT AVRO)` (and via the iceberg extension's manifest writes) on Azure ADLS Gen2 (`abfss://`) silently produces 0-byte files. The destination blob is created but contains nothing, and any subsequent reader fails with `Cannot read 4 bytes from memory buffer`. On local FS / S3 this is harmless and never observed, which is why it has lain dormant.

Filed downstream against duckdb-iceberg as duckdb/duckdb-iceberg#979 with end-to-end empirical evidence (Polaris vending SAS, ADLS REST list showing 0-byte avro). Same root cause as the throwaway comment in duckdb/duckdb-iceberg#834 (\"I always have a blank metadata avro file\" — workaround was fsspec/adlfs, which Closes on file-object destruction so writes commit).

## Root cause

The avro `CopyFunction` never calls `Close()` (or `Sync()`) on its underlying `FileHandle`:

- `WriteAvroFinalize` was `return;` — a no-op.
- `~WriteAvroGlobalState` only tore down the avro library state (`avro_file_writer_close`).
- `FileHandle::~FileHandle()` in DuckDB is empty — destruction does **not** call `Close()`.

For local FS / S3, `Write()` commits the bytes inline, so the missing `Close()` doesn't bite. For Azure DFS:

- `AzureDfsStorageFileSystem::Write` calls `file_client.Append(...)` — appends to ADLS Gen2 *without* committing.
- `AzureDfsStorageFileHandle::Close()` is the only path that runs `Sync(true)` → `file_client.Flush(...)` (the actual commit).

Without an explicit `handle->Close()` from the writer, the bytes stay uncommitted and the blob is left at 0.

Other writers do this correctly:
- `ParquetWriter::Finalize()` → `BufferedFileWriter::Close()` → `handle->Close()`.
- `WriteCSVFinalize` → `CSVWriter::Close()` → `file_writer->Close()` → `handle->Close()`.

The avro `CopyFunction` was the outlier.

## Fix

Move the cleanup into `WriteAvroFinalize` and call `handle->Close()` there, mirroring the parquet/csv pattern. Keep the destructor as a defensive cleanup (avro library state only — the handle is intentionally not touched there, so error paths don't silently commit partial output).

Also `nullptr`-init the `avro_writer_t` / `avro_file_writer_t` members so the destructor's null-guard is safe in the constructor's `ENOSPC` retry path. (`apache/avro` `lang/c/src/avro/io.h:36,100` confirms both are `struct ... *` typedefs, so nullptr-init compiles to a 0-pointer.)

## Verification

The patched extension links and builds cleanly through duckdb-iceberg's build harness (`DUCKDB_AVRO_DIRECTORY=/tmp/duckdb-avro make release`). I haven't yet run an end-to-end write test against Azurite as part of this PR — happy to add a fake-FS unit test if you'd prefer that pattern (a `FileSystem` subclass whose `Close()` is the only path that materializes the bytes, asserting it gets called); the smoke test in duckdb-iceberg's `test/sql/copy/avro_files_nonzero_local_smoke.test` is honest about being a forward-compat guard rather than a true repro (since local FS doesn't surface the bug).

## Followups

Once this lands, duckdb-iceberg can bump `extension_config.cmake`'s avro `GIT_TAG`. Note for coordination: `main` is already past `a73b60d` (cpp17 migration in `2261198`), so the iceberg bump pulls both changes — worth landing them together.