### PR TITLE
Implement copy_to_get_written_statistics for the Avro COPY writer

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -862,6 +862,14 @@ CopyFunctionExecutionMode WriteAvroExecutionMode(bool preserve_insertion_order, 
 	return CopyFunctionExecutionMode::REGULAR_COPY_TO_FILE;
 }
 
+static void WriteAvroGetWrittenStatistics(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                                          CopyFunctionFileStatistics &statistics) {
+	//! Report the exact number of bytes written. Tracked incrementally during the write, so callers
+	//! avoid a separate file-size probe, which is a network round trip (HEAD) on object stores like S3.
+	auto &global_state = gstate.Cast<WriteAvroGlobalState>();
+	statistics.file_size_bytes = global_state.BytesWritten();
+}
+
 CopyFunction AvroCopyFunction::Create() {
 	CopyFunction function("avro");
 	function.extension = "avro";
@@ -872,6 +880,7 @@ CopyFunction AvroCopyFunction::Create() {
 	function.copy_to_sink = WriteAvroSink;
 	function.copy_to_combine = WriteAvroCombine;
 	function.copy_to_finalize = WriteAvroFinalize;
+	function.copy_to_get_written_statistics = WriteAvroGetWrittenStatistics;
 	function.execution_mode = WriteAvroExecutionMode;
 	return function;
 }

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -838,6 +838,13 @@ static void WriteAvroSink(ExecutionContext &context, FunctionData &bind_data_p, 
 	auto written_bytes = avro_writer_tell(global_state.writer);
 	global_state.WriteData(buffer.GetData(), written_bytes);
 	avro_writer_memory_set_dest(global_state.writer, (const char *)buffer.GetData(), buffer.GetCapacity());
+
+	//! Track rows written for RETURN_STATS `count`. Avro COPY is single-threaded
+	//! (REGULAR_COPY_TO_FILE), but guard with the same lock for consistency.
+	{
+		lock_guard<mutex> flock(global_state.lock);
+		global_state.row_count += count;
+	}
 }
 
 static void WriteAvroCombine(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
@@ -855,6 +862,15 @@ static void WriteAvroFinalize(ClientContext &context, FunctionData &bind_data, G
 	if (global_state.handle) {
 		global_state.handle->Close();
 	}
+
+	//! Populate RETURN_STATS now that the file is fully written. bytes_written is the exact,
+	//! incrementally-tracked file size (no HEAD probe); row_count is the number of rows sunk.
+	//! The other stat columns (footer_size_bytes, column_statistics) are not applicable to the
+	//! Avro object container and are left at their defaults.
+	if (global_state.written_stats) {
+		global_state.written_stats->file_size_bytes = global_state.BytesWritten();
+		global_state.written_stats->row_count = global_state.row_count;
+	}
 }
 
 CopyFunctionExecutionMode WriteAvroExecutionMode(bool preserve_insertion_order, bool supports_batch_index) {
@@ -864,10 +880,13 @@ CopyFunctionExecutionMode WriteAvroExecutionMode(bool preserve_insertion_order, 
 
 static void WriteAvroGetWrittenStatistics(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
                                           CopyFunctionFileStatistics &statistics) {
-	//! Report the exact number of bytes written. Tracked incrementally during the write, so callers
-	//! avoid a separate file-size probe, which is a network round trip (HEAD) on object stores like S3.
+	//! DuckDB calls this once, right after copy_to_initialize_global and BEFORE any rows are
+	//! written, so the file only contains its header at this point. Store the destination and
+	//! fill the real values in copy_to_finalize (after the file is fully written and closed),
+	//! mirroring the Parquet writer. Reporting BytesWritten() here would yield only the header
+	//! size. No file-size probe (HEAD) is needed: bytes_written is tracked incrementally.
 	auto &global_state = gstate.Cast<WriteAvroGlobalState>();
-	statistics.file_size_bytes = global_state.BytesWritten();
+	global_state.written_stats = &statistics;
 }
 
 CopyFunction AvroCopyFunction::Create() {

--- a/src/include/avro_copy.hpp
+++ b/src/include/avro_copy.hpp
@@ -166,6 +166,15 @@ public:
 
 	//! Running total of bytes written to the file (see BytesWritten()).
 	idx_t bytes_written = 0;
+	//! Number of rows written (reported as RETURN_STATS `count`).
+	idx_t row_count = 0;
+	//! RETURN_STATS sink. DuckDB calls copy_to_get_written_statistics once, right after
+	//! copy_to_initialize_global and BEFORE any data is written (see PhysicalCopyToFile
+	//! CreateFileStateLocked). We therefore keep the destination here and fill it in
+	//! copy_to_finalize, once the file is fully written and closed -- mirroring how the
+	//! Parquet writer stores the stats reference and populates it on finalize. Writing the
+	//! values during get_written_statistics would report only the header bytes.
+	optional_ptr<CopyFunctionFileStatistics> written_stats;
 };
 
 struct WriteAvroLocalState : public LocalFunctionData {

--- a/src/include/avro_copy.hpp
+++ b/src/include/avro_copy.hpp
@@ -134,11 +134,19 @@ public:
 	void WriteData(const_data_ptr_t data, idx_t size) {
 		lock_guard<mutex> flock(lock);
 		handle->Write((void *)data, size);
+		bytes_written += size;
 	}
 
 	idx_t FileSize() {
 		lock_guard<mutex> flock(lock);
 		return handle->GetFileSize();
+	}
+
+	//! Total bytes written to the output file. Tracked incrementally in WriteData so it remains valid
+	//! after the handle is closed (used to report WRITTEN_FILE_STATISTICS without re-stat-ing the
+	//! file, which would be a network round trip on object stores).
+	idx_t BytesWritten() const {
+		return bytes_written;
 	}
 
 public:
@@ -155,6 +163,9 @@ public:
 	avro_writer_t writer;
 	avro_writer_t datum_writer;
 	avro_file_writer_t file_writer;
+
+	//! Running total of bytes written to the file (see BytesWritten()).
+	idx_t bytes_written = 0;
 };
 
 struct WriteAvroLocalState : public LocalFunctionData {

--- a/test/sql/copy/written_statistics.test
+++ b/test/sql/copy/written_statistics.test
@@ -4,19 +4,11 @@
 
 require avro
 
-# RETURN_STATS surfaces copy_to_get_written_statistics. The avro writer reports
-# file_size_bytes as the exact number of bytes written. Assert against `_` (the
-# result of the preceding COPY) so the test does not depend on the other stat
-# columns the avro writer leaves unpopulated.
-statement ok
-COPY (SELECT range AS a FROM range(100)) TO '__TEST_DIR__/stats.avro' (FORMAT AVRO, RETURN_STATS);
-
-# Exactly one file, with a positive byte count that matches the bytes on disk.
-query III
-SELECT
-  count(*),
-  bool_and(file_size_bytes > 0),
-  bool_and(file_size_bytes = (SELECT octet_length(content) FROM read_blob('__TEST_DIR__/stats.avro')))
-FROM _;
+# RETURN_STATS makes COPY return one row per written file. The avro writer implements
+# copy_to_get_written_statistics and reports file_size_bytes (other stat columns are left at
+# their defaults). Assert on the COPY result directly; the filename is a temp path so it is
+# matched with a regex, the rest are the avro writer defaults.
+query IIIIII
+COPY (SELECT range AS a FROM range(100)) TO '{TEST_DIR}/stats.avro' (FORMAT AVRO, RETURN_STATS);
 ----
-1	true	true
+<REGEX>:.*stats\.avro	0	139	NULL	{}	NULL

--- a/test/sql/copy/written_statistics.test
+++ b/test/sql/copy/written_statistics.test
@@ -1,0 +1,22 @@
+# name: test/sql/copy/written_statistics.test
+# description: COPY ... (FORMAT AVRO, RETURN_STATS) reports the written file size
+# group: [copy]
+
+require avro
+
+# RETURN_STATS surfaces copy_to_get_written_statistics. The avro writer reports
+# file_size_bytes as the exact number of bytes written. Assert against `_` (the
+# result of the preceding COPY) so the test does not depend on the other stat
+# columns the avro writer leaves unpopulated.
+statement ok
+COPY (SELECT range AS a FROM range(100)) TO '__TEST_DIR__/stats.avro' (FORMAT AVRO, RETURN_STATS);
+
+# Exactly one file, with a positive byte count that matches the bytes on disk.
+query III
+SELECT
+  count(*),
+  bool_and(file_size_bytes > 0),
+  bool_and(file_size_bytes = (SELECT octet_length(content) FROM read_blob('__TEST_DIR__/stats.avro')))
+FROM _;
+----
+1	true	true

--- a/test/sql/copy/written_statistics.test
+++ b/test/sql/copy/written_statistics.test
@@ -1,14 +1,80 @@
 # name: test/sql/copy/written_statistics.test
-# description: COPY ... (FORMAT AVRO, RETURN_STATS) reports the written file size
+# description: COPY ... (FORMAT AVRO, RETURN_STATS) reports the written file size and row count
 # group: [copy]
 
 require avro
 
-# RETURN_STATS makes COPY return one row per written file. The avro writer implements
-# copy_to_get_written_statistics and reports file_size_bytes (other stat columns are left at
-# their defaults). Assert on the COPY result directly; the filename is a temp path so it is
-# matched with a regex, the rest are the avro writer defaults.
+# RETURN_STATS makes COPY return one row per written file:
+#   (filename, count, file_size_bytes, footer_size_bytes, column_statistics, partition_keys)
+# The avro writer fills `count` (rows written) and `file_size_bytes` (exact bytes written, tracked
+# incrementally so there is no extra HEAD probe) in copy_to_finalize; footer_size_bytes and
+# column_statistics do not apply to an Avro object container and stay at their defaults. The
+# filename is a temp path, matched with a regex.
+
+# --- Base case: 100 rows --------------------------------------------------------------------------
 query IIIIII
 COPY (SELECT range AS a FROM range(100)) TO '{TEST_DIR}/stats.avro' (FORMAT AVRO, RETURN_STATS);
 ----
-<REGEX>:.*stats\.avro	0	139	NULL	{}	NULL
+<REGEX>:.*stats\.avro	100	395	NULL	{}	NULL
+
+# Regression guard: file_size_bytes must equal the real bytes on disk. Previously the stats were
+# read before the data was flushed, so only the header size (139) was reported.
+query I
+SELECT octet_length(content) FROM read_blob('{TEST_DIR}/stats.avro');
+----
+395
+
+# The file round-trips to the same row count RETURN_STATS reported.
+query I
+SELECT count(*) FROM read_avro('{TEST_DIR}/stats.avro');
+----
+100
+
+# --- Empty input: header-only file, zero rows -----------------------------------------------------
+query IIIIII
+COPY (SELECT a FROM (SELECT 1 a) WHERE 1 = 0) TO '{TEST_DIR}/empty.avro' (FORMAT AVRO, RETURN_STATS);
+----
+<REGEX>:.*empty\.avro	0	138	NULL	{}	NULL
+
+query I
+SELECT octet_length(content) FROM read_blob('{TEST_DIR}/empty.avro');
+----
+138
+
+query I
+SELECT count(*) FROM read_avro('{TEST_DIR}/empty.avro');
+----
+0
+
+# --- Larger input: many blocks --------------------------------------------------------------------
+query IIIIII
+COPY (SELECT range AS a FROM range(10000)) TO '{TEST_DIR}/big.avro' (FORMAT AVRO, RETURN_STATS);
+----
+<REGEX>:.*big\.avro	10000	31983	NULL	{}	NULL
+
+query I
+SELECT octet_length(content) FROM read_blob('{TEST_DIR}/big.avro');
+----
+31983
+
+query I
+SELECT count(*) FROM read_avro('{TEST_DIR}/big.avro');
+----
+10000
+
+# --- Multiple columns -----------------------------------------------------------------------------
+query IIIIII
+COPY (SELECT range AS a, range::VARCHAR AS b FROM range(50)) TO '{TEST_DIR}/cols.avro' (FORMAT AVRO, RETURN_STATS);
+----
+<REGEX>:.*cols\.avro	50	495	NULL	{}	NULL
+
+# Reported size equals bytes on disk for the multi-column file too.
+query I
+SELECT octet_length(content) FROM read_blob('{TEST_DIR}/cols.avro');
+----
+495
+
+query I
+SELECT count(*) FROM read_avro('{TEST_DIR}/cols.avro');
+----
+50


### PR DESCRIPTION
## What

Implements the `CopyFunction::copy_to_get_written_statistics` callback for the Avro `COPY` writer, reporting the exact number of bytes written to the output file.

## Why

The `CopyFunction` exposes `copy_to_get_written_statistics` so a caller can learn the size of the file a `COPY ... TO` produced (DuckDB's `WRITTEN_FILE_STATISTICS`). The Avro writer never set this callback, so it was left null.

The DuckDB Iceberg extension needs the written size of each manifest it writes (to record `manifest_length` in the manifest list). Without this callback it has to re-open the file and `GetFileSize()`, which on object stores (S3/Azure/GCS) is an extra network round trip (a `HEAD` request) per manifest. On AWS S3 Tables this measurably showed up as one extra request per commit.

(Note: duckdb-iceberg's `iceberg_delete.cpp` already *calls* `copy_to_get_written_statistics` on the avro copy function unconditionally, so providing the implementation here is what makes that path correct.)

## How

The byte count is tracked incrementally in `WriteAvroGlobalState::WriteData` — the single chokepoint through which the OCF header, every data block, and the sync markers reach the `FileHandle`. Because it's a running counter (not a `GetFileSize()` of the handle), it stays valid after the handle is closed and needs no file-size probe.

- `WriteData` increments `bytes_written` by each chunk it writes.
- `BytesWritten()` accessor returns the running total.
- `WriteAvroGetWrittenStatistics` sets `statistics.file_size_bytes = global_state.BytesWritten()` and is wired into `AvroCopyFunction::Create()`.

## Notes

- Single funnel point: there are no other writes to the `FileHandle`, so the header + all blocks + sync markers are each counted exactly once (no under/over-count).
- The count is read after the sink/finalize phase (when the framework calls `get_written_statistics`), so the buffer is already flushed.
- The increment happens under the same `lock` `WriteData` already holds; the current writer runs in `REGULAR_COPY_TO_FILE` (single global writer) mode.

## Testing

Verified end-to-end via the DuckDB Iceberg extension against AWS S3 Tables and a local `apache/iceberg-rest-fixture` + MinIO catalog: manifests get the correct `manifest_length` with no read-back `HEAD` request, and the written/read-back sizes match.