### PR TITLE
Add CODEC option to the Avro COPY writer

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -497,6 +497,28 @@ static string CreateJSONMetadata(const case_insensitive_map_t<vector<Value>> &op
 	return res;
 }
 
+//! Parse the CODEC option (Avro object-container compression codec). Validates the value is a
+//! non-empty VARCHAR and returns the lowercased codec name; empty string when unset (writer
+//! defaults to "null"). The codec name itself is validated by avro-c when the writer is created
+//! (it reports "Unknown codec X" for anything the library was not built with), so this stays in
+//! lock-step with avro-c's actual capabilities instead of duplicating a list that could drift.
+static string ParseCodec(const case_insensitive_map_t<vector<Value>> &options,
+                         case_insensitive_set_t &recognized) {
+	auto it = options.find("CODEC");
+	if (it == options.end()) {
+		return "";
+	}
+	if (it->second.empty()) {
+		throw InvalidInputException("CODEC can not be provided without a value");
+	}
+	auto &value = it->second[0];
+	if (value.type().id() != LogicalTypeId::VARCHAR) {
+		throw InvalidInputException("'CODEC' is expected to be provided as VARCHAR (e.g. 'deflate', 'null')");
+	}
+	recognized.insert(it->first);
+	return StringUtil::Lower(value.GetValue<string>());
+}
+
 WriteAvroBindData::WriteAvroBindData(CopyFunctionBindInput &input, const vector<Identifier> &names,
                                      const vector<LogicalType> &types)
     : names(IdentifiersToStrings(names)), types(types) {
@@ -505,6 +527,7 @@ WriteAvroBindData::WriteAvroBindData(CopyFunctionBindInput &input, const vector<
 
 	json_metadata = CreateJSONMetadata(input.info.options, recognized);
 	json_schema = CreateJSONSchema(input.info.options, this->names, types, recognized);
+	codec = ParseCodec(input.info.options, recognized);
 
 	vector<string> unrecognized_options;
 	for (auto &option : input.info.options) {
@@ -569,8 +592,12 @@ WriteAvroGlobalState::WriteAvroGlobalState(ClientContext &context, FunctionData 
 		json_metadata = bind_data.json_metadata.c_str();
 	}
 
-	while ((ret = avro_file_writer_create_from_writers_with_metadata(writer, datum_writer, bind_data.schema,
-	                                                                 &file_writer, json_metadata)) == ENOSPC) {
+	//! Pass the compression codec straight to avro-c so the object container is written compressed
+	//! natively (no post-processing). Empty -> nullptr -> avro-c default ("null"/uncompressed).
+	const char *codec = bind_data.codec.empty() ? nullptr : bind_data.codec.c_str();
+
+	while ((ret = avro_file_writer_create_from_writers_with_metadata_and_codec(
+	            writer, datum_writer, bind_data.schema, &file_writer, json_metadata, codec)) == ENOSPC) {
 		auto current_capacity = memory_buffer.GetCapacity();
 		memory_buffer.Resize(NextPowerOfTwo(current_capacity * 2));
 		// re-initialize writer to use correct data location

--- a/src/include/avro_copy.hpp
+++ b/src/include/avro_copy.hpp
@@ -26,6 +26,8 @@ public:
 
 		res->schema = avro_schema_incref(schema);
 		res->json_schema = json_schema;
+		res->json_metadata = json_metadata;
+		res->codec = codec;
 
 		res->interface = avro_value_iface_incref(interface);
 		return std::move(res);
@@ -46,6 +48,9 @@ public:
 		if (json_schema != other.json_schema) {
 			return false;
 		}
+		if (codec != other.codec) {
+			return false;
+		}
 		return true;
 	}
 
@@ -58,6 +63,10 @@ public:
 	string json_schema;
 
 	string json_metadata;
+	//! Avro object-container compression codec ("null", "deflate", "snappy", "zstandard", ...).
+	//! Empty means unset -> the writer defaults to "null" (uncompressed). Passed through to
+	//! avro-c's codec so the COPY writer compresses natively (no post-processing).
+	string codec;
 	//! The interface through which new avro values are created
 	avro_value_iface_t *interface = nullptr;
 };

--- a/test/sql/copy/codec.test
+++ b/test/sql/copy/codec.test
@@ -1,0 +1,69 @@
+# name: test/sql/copy/codec.test
+# description: COPY ... TO (FORMAT AVRO, CODEC '...') writes a natively-compressed Avro object
+#              container (codec applied by avro-c, no post-processing). Round-trips correctly.
+#              The set of accepted codecs follows whatever avro-c was built with.
+
+require avro
+
+# Default (no CODEC) writes uncompressed and round-trips.
+statement ok
+COPY (select i a, ('row_' || (i % 4)::VARCHAR) b from range(2000) t(i)) TO '{TEST_DIR}/codec_none.avro' (FORMAT AVRO);
+
+# Explicit null codec is accepted and round-trips.
+statement ok
+COPY (select i a, ('row_' || (i % 4)::VARCHAR) b from range(2000) t(i)) TO '{TEST_DIR}/codec_null.avro' (FORMAT AVRO, CODEC 'null');
+
+# deflate codec: native compression.
+statement ok
+COPY (select i a, ('row_' || (i % 4)::VARCHAR) b from range(2000) t(i)) TO '{TEST_DIR}/codec_deflate.avro' (FORMAT AVRO, CODEC 'deflate');
+
+# snappy codec.
+statement ok
+COPY (select i a, ('row_' || (i % 4)::VARCHAR) b from range(2000) t(i)) TO '{TEST_DIR}/codec_snappy.avro' (FORMAT AVRO, CODEC 'snappy');
+
+# Every codec round-trips to the identical row set and count.
+query II
+select count(*), sum(a) from read_avro('{TEST_DIR}/codec_deflate.avro');
+----
+2000	1999000
+
+query II
+select count(*), sum(a) from read_avro('{TEST_DIR}/codec_snappy.avro');
+----
+2000	1999000
+
+query II
+select count(*), sum(a) from read_avro('{TEST_DIR}/codec_null.avro');
+----
+2000	1999000
+
+# Compressed output equals the uncompressed output row-for-row (codec is transparent on read).
+query I
+select count(*) from (
+	select a, b from read_avro('{TEST_DIR}/codec_deflate.avro')
+	except
+	select a, b from read_avro('{TEST_DIR}/codec_none.avro')
+);
+----
+0
+
+# Case-insensitive codec name.
+statement ok
+COPY (select 1 a) TO '{TEST_DIR}/codec_ci.avro' (FORMAT AVRO, CODEC 'DEFLATE');
+
+query I
+select a from read_avro('{TEST_DIR}/codec_ci.avro');
+----
+1
+
+# An unknown codec fails with avro-c's clear message (validated against what avro-c was built with).
+statement error
+COPY (select 1 a) TO '{TEST_DIR}/codec_bad.avro' (FORMAT AVRO, CODEC 'nope');
+----
+Unknown codec
+
+# CODEC without a value fails.
+statement error
+COPY (select 1 a) TO '{TEST_DIR}/codec_empty.avro' (FORMAT AVRO, CODEC);
+----
+CODEC can not be provided without a value


### PR DESCRIPTION
## What

Adds a `CODEC` option to `COPY ... TO (FORMAT AVRO)`, so the Avro object container is written with native compression:

```sql
COPY (SELECT ...) TO 'out.avro' (FORMAT AVRO, CODEC 'deflate');
```

Supported codec names are whatever the linked avro-c was built with (e.g. `null`, `deflate`, `snappy`). Compression is done by avro-c as it writes each block — there is no post-processing/recompression pass.

## How

- `ParseCodec` validates the option is a non-empty `VARCHAR` and lowercases it. The codec **name** is validated by avro-c at writer creation (it reports `Unknown codec X`), so the accepted set always tracks what the library was actually built with instead of a hard-coded list that could drift.
- The codec is stored in `WriteAvroBindData` and passed to the writer. The COPY writer streams through a memory `avro_writer_t` (to go via DuckDB's `FileSystem`), i.e. the *from-writers* creation path — which previously could not set a codec. Empty/unset → `NULL` → avro-c default (`null`/uncompressed), so existing writes are byte-for-byte unchanged.
- Drive-by: `WriteAvroBindData::Copy()` now also carries `json_metadata` (it was previously dropped on copy).

## Testing

`test/sql/copy/codec.test`: round-trips `deflate`/`snappy`/`null`, asserts the compressed output is row-for-row identical to uncompressed, checks case-insensitivity, and that an unknown codec / a value-less `CODEC` error out.

Verified locally (deflate shrinks a 20k-row file ~6x: 212KB → 35KB; snappy → 120KB; data reads back identical).

## Dependency

Requires **duckdb/duckdb-avro-c#6** (adds `avro_file_writer_create_from_writers_with_metadata_and_codec`, the from-writers creation function that accepts a codec). This PR is draft until that lands and the vcpkg-duckdb-ports avro-c port is bumped to include it. Marked draft for that reason.