### PR TITLE
Use field ids for record name

### DIFF
--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -390,8 +390,11 @@ private:
 	yyjson_mut_val *CreateStructField(const string &name, const LogicalType &type,
 	                                  optional_ptr<avro::FieldID> field_id) {
 		auto struct_field = yyjson_mut_obj(doc);
-		const char *struct_name = name.c_str();
-		auto struct_field_type = CreateJSONType(type, field_id, struct_name);
+		auto schema_name = name;
+		if (type.id() == LogicalTypeId::STRUCT && field_id) {
+			schema_name = StringUtil::Format("r%d", field_id->GetFieldId());
+		}
+		auto struct_field_type = CreateJSONType(type, field_id, schema_name.c_str());
 		if (!field_id || field_id->nullable) {
 			auto union_array = yyjson_mut_arr(doc);
 			yyjson_mut_arr_add_strcpy(doc, union_array, "null");

--- a/src/avro_copy.cpp
+++ b/src/avro_copy.cpp
@@ -338,6 +338,8 @@ public:
 		if (IsNamedSchema(type)) {
 			D_ASSERT(IsJSONObject(type_val));
 			if (preset_schema_name) {
+				VerifyAvroName(preset_schema_name);
+				VerifyNamedSchemaUniqueness(preset_schema_name);
 				yyjson_mut_obj_add_strcpy(doc, type_val, "name", preset_schema_name);
 			} else {
 				auto named_schema = GenerateSchemaName(avro_type_str);
@@ -348,6 +350,8 @@ public:
 	}
 
 	string GenerateJSON() {
+		VerifyAvroName(root_name);
+		VerifyNamedSchemaUniqueness(root_name);
 		yyjson_mut_obj_add_str(doc, root_object, "type", "record");
 		yyjson_mut_obj_add_strcpy(doc, root_object, "name", root_name.c_str());
 		auto array = yyjson_mut_obj_add_arr(doc, root_object, "fields");

--- a/test/sql/copy/field_ids.test
+++ b/test/sql/copy/field_ids.test
@@ -53,6 +53,24 @@ WHERE key = 'avro.schema';
 ----
 r2	r102
 
+# A root record can collide with the Iceberg-style name of a nested record that
+# has a field ID. Reject the collision before producing an invalid Avro schema:
+# named types must be unique across the entire schema.
+statement error
+COPY (
+	SELECT {'value': 84} data_file
+) TO '{TEST_DIR}/field_id_record_name_collision.avro' (
+	FIELD_IDS {
+		'data_file': {
+			'__duckdb_field_id': 2,
+			'value': 3
+		}
+	},
+	ROOT_NAME 'r2'
+);
+----
+Binder Error: Avro schema by the name of 'r2' already exists, names of 'record', 'enum' and 'fixed' types have to be distinct
+
 statement ok
 COPY (
 	select [

--- a/test/sql/copy/field_ids.test
+++ b/test/sql/copy/field_ids.test
@@ -22,6 +22,37 @@ COPY (
 	ROOT_NAME 'test'
 );
 
+# Struct record names are inferred from their field IDs, following the naming
+# convention used by Apache Iceberg's Avro writer.
+statement ok
+COPY (
+	SELECT {
+		'partition': {
+			'partition_value': 42
+		}
+	} data_file
+) TO '{TEST_DIR}/field_id_record_names.avro' (
+	FIELD_IDS {
+		'data_file': {
+			'__duckdb_field_id': 2,
+			'partition': {
+				'__duckdb_field_id': 102,
+				'partition_value': 1000
+			}
+		}
+	},
+	ROOT_NAME 'manifest_entry'
+);
+
+query II
+SELECT
+	regexp_extract_all(value, '"type":"record","name":"([^"]+)"', 1)[2],
+	regexp_extract_all(value, '"type":"record","name":"([^"]+)"', 1)[3]
+FROM avro_metadata('{TEST_DIR}/field_id_record_names.avro')
+WHERE key = 'avro.schema';
+----
+r2	r102
+
 statement ok
 COPY (
 	select [


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/duckdb-iceberg/issues/1245

TL;DR BigQuery requires the Avro record names to follow a certain pattern that isn't documented anywhere or enforced by the spec, and is therefore an ungrounded assumption.