### PR TITLE
[MultiFileReader] Implement `AvroFileLocalState` to hold the local state for a single thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(THREADSAFE ON CACHE BOOL "" FORCE)
 
 # avro-c still declares an old cmake_minimum_required(). With newer CMake
 # releases we need to raise the policy floor before adding the subdirectory.

--- a/src/avro_multi_file_info.cpp
+++ b/src/avro_multi_file_info.cpp
@@ -30,6 +30,7 @@ struct AvroMultiFileData final : public TableFunctionData {
 public:
 	AvroMultiFileData() = default;
 	AvroFileReaderOptions options;
+	idx_t initial_file_block_count = 1;
 };
 
 unique_ptr<TableFunctionData> AvroMultiFileInfo::InitializeBindData(MultiFileBindData &multi_file_data,
@@ -52,14 +53,23 @@ void AvroMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
 	D_ASSERT(names.size() == return_types.size());
 }
 
+void AvroMultiFileInfo::FinalizeBindData(MultiFileBindData &multi_file_data) {
+	if (!multi_file_data.initial_reader) {
+		return;
+	}
+	auto &avro_data = multi_file_data.bind_data->Cast<AvroMultiFileData>();
+	auto &initial_reader = multi_file_data.initial_reader->Cast<AvroReader>();
+	avro_data.initial_file_block_count = initial_reader.NumBlocks();
+}
+
 optional_idx AvroMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data_p,
                                            const MultiFileGlobalState &global_state, FileExpandResult expand_result) {
 	if (expand_result == FileExpandResult::MULTIPLE_FILES) {
 		// always launch max threads if we are reading multiple files
 		return {};
 	}
-	// Otherwise, only one thread
-	return 1;
+	auto &avro_data = bind_data_p.bind_data->Cast<AvroMultiFileData>();
+	return MaxValue<idx_t>(avro_data.initial_file_block_count, 1);
 }
 
 struct AvroFileGlobalState : public GlobalTableFunctionState {
@@ -68,9 +78,7 @@ public:
 	~AvroFileGlobalState() override = default;
 
 public:
-	//! TODO: this should contain the state of the current file being scanned
-	//! so we can parallelize over a single file
-	set<idx_t> files;
+	idx_t next_block_index = 0;
 };
 
 unique_ptr<GlobalTableFunctionState> AvroMultiFileInfo::InitializeGlobalState(ClientContext &context,
@@ -87,6 +95,8 @@ public:
 
 public:
 	shared_ptr<AvroReader> file_scan;
+	unique_ptr<AvroReaderScanState> scan_state;
+	idx_t block_index = 0;
 	ClientContext &context;
 };
 
@@ -118,20 +128,37 @@ bool AvroReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionSt
                                    LocalTableFunctionState &lstate_p) {
 	auto &gstate = gstate_p.Cast<AvroFileGlobalState>();
 	auto &lstate = lstate_p.Cast<AvroFileLocalState>();
-	if (gstate.files.count(file_list_idx.GetIndex())) {
-		// Return false because we don't currently support more than one thread
-		// scanning a file.
+	if (gstate.next_block_index >= NumBlocks()) {
 		return false;
 	}
-	gstate.files.insert(file_list_idx.GetIndex());
+	if (!lstate.file_scan || lstate.file_scan.get() != this) {
+		lstate.scan_state.reset();
+	}
 	lstate.file_scan = shared_ptr_cast<BaseFileReader, AvroReader>(shared_from_this());
+	lstate.block_index = gstate.next_block_index++;
 	return true;
+}
+
+void AvroReader::PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate_p,
+                             LocalTableFunctionState &lstate_p) {
+	auto &lstate = lstate_p.Cast<AvroFileLocalState>();
+	if (!lstate.scan_state) {
+		lstate.scan_state = make_uniq<AvroReaderScanState>(context, *this);
+	}
+	lstate.scan_state->SelectBlock(lstate.block_index);
 }
 
 AsyncResult AvroReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                              LocalTableFunctionState &local_state_p, DataChunk &chunk) {
-	Read(chunk);
+	auto &lstate = local_state_p.Cast<AvroFileLocalState>();
+	D_ASSERT(lstate.scan_state);
+	Read(*lstate.scan_state, chunk);
 	return chunk.size() ? AsyncResult(SourceResultType::HAVE_MORE_OUTPUT) : AsyncResult(SourceResultType::FINISHED);
+}
+
+void AvroReader::FinishFile(ClientContext &context, GlobalTableFunctionState &gstate_p) {
+	auto &gstate = gstate_p.Cast<AvroFileGlobalState>();
+	gstate.next_block_index = 0;
 }
 
 InsertionOrderPreservingMap<Value> AvroReader::GetMetadata() const {

--- a/src/avro_reader.cpp
+++ b/src/avro_reader.cpp
@@ -221,11 +221,14 @@ AvroReader::AvroReader(ClientContext &context, OpenFileInfo file, const AvroFile
 	local_buffer = Allocator::DefaultAllocator().Allocate(total_size);
 	fs.Read(*file_handle, local_buffer.get(), total_size);
 
-	auto avro_reader = avro_reader_memory(const_char_ptr_cast(local_buffer.get()), total_size);
-
-	if (avro_reader_reader(avro_reader, &reader)) {
+	if (avro_file_reader_memory(const_char_ptr_cast(local_buffer.get()), total_size, &reader)) {
 		throw InvalidInputException(avro_strerror());
 	}
+	size_t file_block_count;
+	if (avro_file_reader_get_block_count(reader, &file_block_count)) {
+		throw InvalidInputException(avro_strerror());
+	}
+	block_count = file_block_count;
 
 	auto avro_schema = avro_file_reader_get_writer_schema(reader);
 	auto schema_name = avro_schema_name(avro_schema);
@@ -234,11 +237,10 @@ AvroReader::AvroReader(ClientContext &context, OpenFileInfo file, const AvroFile
 	avro_type = TransformSchema(avro_schema, {});
 	auto root = AvroType::TransformAvroType(root_name, avro_type);
 	duckdb_type = root.type;
-	read_chunk.Initialize(context, {duckdb_type}, STANDARD_VECTOR_SIZE);
-
-	auto interface = avro_generic_class_from_schema(avro_schema);
-	avro_generic_value_new(interface, &value);
-	avro_value_iface_decref(interface);
+	value_iface = avro_generic_class_from_schema(avro_schema);
+	if (!value_iface) {
+		throw InvalidInputException(avro_strerror());
+	}
 
 	// special handling for root structs, we pull up the entries
 	if (duckdb_type.id() == LogicalTypeId::STRUCT) {
@@ -248,6 +250,30 @@ AvroReader::AvroReader(ClientContext &context, OpenFileInfo file, const AvroFile
 		columns.push_back(std::move(root));
 	}
 	avro_schema_decref(avro_schema);
+}
+
+AvroReaderScanState::AvroReaderScanState(ClientContext &context, AvroReader &reader_p) : reader(reader_p) {
+	if (avro_file_block_reader_create(reader.reader, &block_reader)) {
+		throw InvalidInputException(avro_strerror());
+	}
+	if (avro_generic_value_new(reader.value_iface, &value)) {
+		avro_file_block_reader_close(block_reader);
+		block_reader = nullptr;
+		throw InvalidInputException(avro_strerror());
+	}
+	read_chunk.Initialize(context, {reader.duckdb_type}, STANDARD_VECTOR_SIZE);
+}
+
+AvroReaderScanState::~AvroReaderScanState() {
+	avro_value_decref(&value);
+	avro_file_block_reader_close(block_reader);
+}
+
+void AvroReaderScanState::SelectBlock(idx_t block_index) {
+	avro_value_reset(&value);
+	if (avro_file_block_reader_select_block(block_reader, block_index)) {
+		throw InvalidInputException(avro_strerror());
+	}
 }
 
 static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vector &target, idx_t out_idx) {
@@ -607,17 +633,21 @@ static void TransformValue(avro_value *avro_val, const AvroType &avro_type, Vect
 	}
 }
 
-void AvroReader::Read(DataChunk &output) {
+void AvroReader::Read(AvroReaderScanState &scan_state, DataChunk &output) {
 	idx_t out_idx = 0;
-	read_chunk.Reset();
+	scan_state.read_chunk.Reset();
 
-	D_ASSERT(read_chunk.ColumnCount() == 1);
-	auto &read_vec = read_chunk.data[0];
-	while (avro_file_reader_read_value(reader, &value) == 0) {
-		TransformValue(&value, avro_type, read_vec, out_idx++);
+	D_ASSERT(scan_state.read_chunk.ColumnCount() == 1);
+	auto &read_vec = scan_state.read_chunk.data[0];
+	int ret = 0;
+	while ((ret = avro_file_block_reader_read_value(scan_state.block_reader, &scan_state.value)) == 0) {
+		TransformValue(&scan_state.value, avro_type, read_vec, out_idx++);
 		if (out_idx == STANDARD_VECTOR_SIZE) {
 			break;
 		}
+	}
+	if (ret != 0 && ret != EOF) {
+		throw InvalidInputException(avro_strerror());
 	}
 
 	// pull up root struct into output chunk

--- a/src/include/avro_multi_file_info.hpp
+++ b/src/include/avro_multi_file_info.hpp
@@ -34,6 +34,7 @@ struct AvroMultiFileInfo : MultiFileReaderInterface {
 	//! 2. union_by_name = True.
 	void BindReader(ClientContext &context, vector<LogicalType> &return_types, vector<Identifier> &names,
 	                MultiFileBindData &bind_data) override;
+	void FinalizeBindData(MultiFileBindData &multi_file_data) override;
 
 	optional_idx MaxThreads(const MultiFileBindData &bind_data_p, const MultiFileGlobalState &global_state,
 	                        FileExpandResult expand_result) override;

--- a/src/include/avro_reader.hpp
+++ b/src/include/avro_reader.hpp
@@ -8,18 +8,38 @@
 
 namespace duckdb {
 
+class AvroReader;
+
+class AvroReaderScanState {
+public:
+	AvroReaderScanState(ClientContext &context, AvroReader &reader);
+	~AvroReaderScanState();
+
+	void SelectBlock(idx_t block_index);
+
+public:
+	AvroReader &reader;
+	avro_file_block_reader_t block_reader = nullptr;
+	avro_value_t value;
+	DataChunk read_chunk;
+};
+
 class AvroReader : public BaseFileReader {
 public:
 	AvroReader(ClientContext &context, const OpenFileInfo file,
 	           const AvroFileReaderOptions &options = AvroFileReaderOptions());
 
 	~AvroReader() {
-		avro_value_decref(&value);
+		avro_value_iface_decref(value_iface);
 		avro_file_reader_close(reader);
 	}
 
 public:
-	void Read(DataChunk &output);
+	void Read(AvroReaderScanState &scan_state, DataChunk &output);
+
+	idx_t NumBlocks() const {
+		return block_count;
+	}
 
 	string GetReaderType() const override {
 		return "Avro";
@@ -27,16 +47,19 @@ public:
 
 	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
 	                       LocalTableFunctionState &lstate) override;
+	void PrepareScan(ClientContext &context, GlobalTableFunctionState &gstate,
+	                 LocalTableFunctionState &lstate) override;
 	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
 	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+	void FinishFile(ClientContext &context, GlobalTableFunctionState &gstate) override;
 	InsertionOrderPreservingMap<Value> GetMetadata() const override;
 
 	string GetMetadataValue(const string &key) const;
 
 public:
 	avro_file_reader_t reader;
-	avro_value_t value;
-	DataChunk read_chunk;
+	avro_value_iface_t *value_iface;
+	idx_t block_count;
 
 	AllocatedData local_buffer;
 	AvroType avro_type;

--- a/test/sql/parallel_scan.test
+++ b/test/sql/parallel_scan.test
@@ -1,0 +1,67 @@
+# name: test/sql/parallel_scan.test
+# description: scan blocks from a single Avro object container in parallel
+# group: [sql]
+
+require avro
+
+statement ok
+SET threads=4
+
+# COPY flushes an Avro block for every input chunk, producing many independently decodable blocks.
+statement ok
+COPY (
+	SELECT i::BIGINT AS id,
+	       ('row_' || (i % 100)::VARCHAR) AS payload,
+	       [i::BIGINT, (i + 1)::BIGINT] AS items
+	FROM range(20000) t(i)
+) TO '{TEST_DIR}/parallel.avro' (FORMAT AVRO)
+
+query IIIII
+SELECT count(*), sum(id), min(id), max(id), sum(items[2])
+FROM read_avro('{TEST_DIR}/parallel.avro')
+----
+20000	199990000	0	19999	200010000
+
+statement ok
+COPY (
+	SELECT i::BIGINT AS id, ('compressed_' || i::VARCHAR) AS payload
+	FROM range(20000) t(i)
+) TO '{TEST_DIR}/parallel_deflate.avro' (FORMAT AVRO, CODEC 'deflate')
+
+query III
+SELECT count(*), sum(id), count(DISTINCT payload)
+FROM read_avro('{TEST_DIR}/parallel_deflate.avro')
+----
+20000	199990000	20000
+
+# Empty and single-block containers retain their normal behavior.
+statement ok
+COPY (SELECT 1::BIGINT AS id WHERE false) TO '{TEST_DIR}/parallel_empty.avro' (FORMAT AVRO)
+
+query I
+SELECT count(*) FROM read_avro('{TEST_DIR}/parallel_empty.avro')
+----
+0
+
+statement ok
+COPY (SELECT 42::BIGINT AS id) TO '{TEST_DIR}/parallel_single.avro' (FORMAT AVRO)
+
+query I
+SELECT id FROM read_avro('{TEST_DIR}/parallel_single.avro')
+----
+42
+
+# Multiple files still combine file-level and block-level scheduling.
+statement ok
+COPY (SELECT i::BIGINT AS id FROM range(5000) t(i))
+TO '{TEST_DIR}/parallel_1.avro' (FORMAT AVRO)
+
+statement ok
+COPY (SELECT i::BIGINT AS id FROM range(5000, 10000) t(i))
+TO '{TEST_DIR}/parallel_2.avro' (FORMAT AVRO)
+
+query II
+SELECT count(*), sum(id)
+FROM read_avro(['{TEST_DIR}/parallel_1.avro', '{TEST_DIR}/parallel_2.avro'])
+----
+10000	49995000


### PR DESCRIPTION
In `TryInitializeScan` the local state will be handed a new block to read from the Avro file.