### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -18,7 +18,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: avro
-      duckdb_version: 9c21294d984dfe9a1da5d055b5fce3e8a0d634b2
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       ci_tools_version: main
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_gcc4'
 
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: avro
-      duckdb_version: 9c21294d984dfe9a1da5d055b5fce3e8a0d634b2
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       ci_tools_version: main
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_gcc4'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:

It also bumps the duckdb submodules and `.github/workflows/MainDistributionPipeline.yml` to v2.0.0.
